### PR TITLE
API: use access token for access

### DIFF
--- a/lib/humaans.ex
+++ b/lib/humaans.ex
@@ -8,11 +8,11 @@ defmodule Humaans do
   @doc """
   Creates a new client with the given base URL and API key.
   """
-  @spec new(api_key :: String.t()) :: map()
-  def new(api_key) do
+  @spec new(access_token :: String.t()) :: map()
+  def new(access_token) do
     Req.new(
       base_url: @base_url,
-      auth: {:bearer, api_key},
+      auth: {:bearer, access_token},
       headers: [{"Accept", "application/json"}]
     )
   end

--- a/lib/humaans.ex
+++ b/lib/humaans.ex
@@ -1,6 +1,8 @@
 defmodule Humaans do
   @moduledoc """
-  A client for the Humaans API.
+  A HTTP client for the Humaans API.
+
+  [Humaans API Docs](https://docs.humaans.io/api/)
   """
 
   @base_url "https://app.humaans.io/api"

--- a/lib/humaans/client/req.ex
+++ b/lib/humaans/client/req.ex
@@ -13,7 +13,7 @@ defmodule Humaans.Client.Req do
   def new do
     Req.new(
       base_url: @base_url,
-      auth: {:bearer, api_key()},
+      auth: {:bearer, access_token()},
       headers: [{"Accept", "application/json"}]
     )
   end
@@ -53,8 +53,8 @@ defmodule Humaans.Client.Req do
     |> Req.patch(url: path, params: params)
   end
 
-  defp api_key do
-    System.get_env("HUMAANS_API_KEY") ||
-      raise "Environment variable HUMAANS_API_KEY is not set"
+  defp access_token do
+    System.get_env("HUMAANS_ACCESS_TOKEN") ||
+      raise "Environment variable HUMAANS_ACCESS_TOKEN is not set"
   end
 end

--- a/lib/humaans/client/req.ex
+++ b/lib/humaans/client/req.ex
@@ -9,52 +9,52 @@ defmodule Humaans.Client.Req do
 
   @base_url "https://app.humaans.io/api"
 
-  @spec new() :: Req.Request.t()
-  def new do
-    Req.new(
-      base_url: @base_url,
-      auth: {:bearer, access_token()},
-      headers: [{"Accept", "application/json"}]
-    )
-  end
-
   @impl true
   @spec delete(path :: String.t()) :: Response.t()
   def delete(path) do
-    new()
+    build_client()
     |> Req.delete(url: path)
   end
 
   @impl true
   @spec get(path :: String.t()) :: Response.t()
   def get(path) do
-    new()
+    build_client()
     |> Req.get(url: path)
   end
 
   @impl true
   @spec get(path :: String.t(), params :: keyword()) :: Response.t()
   def get(path, params) do
-    new()
+    build_client()
     |> Req.get(url: path, params: params)
   end
 
   @impl true
   @spec post(path :: String.t(), params :: keyword()) :: Response.t()
   def post(path, params \\ []) do
-    new()
+    build_client()
     |> Req.post(url: path, params: params)
   end
 
   @impl true
   @spec patch(path :: String.t(), params :: keyword()) :: Response.t()
   def patch(path, params \\ []) do
-    new()
+    build_client()
     |> Req.patch(url: path, params: params)
   end
 
-  defp access_token do
-    System.get_env("HUMAANS_ACCESS_TOKEN") ||
-      raise "Environment variable HUMAANS_ACCESS_TOKEN is not set"
+  defp build_client do
+    case Application.fetch_env(:humaans, :access_token) do
+      :error ->
+        raise "No :access_token configuration was found"
+
+      {:ok, access_token} ->
+        Req.new(
+          base_url: @base_url,
+          auth: {:bearer, access_token},
+          headers: [{"Accept", "application/json"}]
+        )
+    end
   end
 end


### PR DESCRIPTION
💁 Humaans use access token as the [nomenclature for accessing their API in the documentation](https://docs.humaans.io/api/#authentication). These changes update the authentication implementation to use this and move the source of this credential to application configuration.