### PR TITLE
API: Add support for Timesheet Entries

### DIFF
--- a/lib/humaans/resources/timesheet_entry.ex
+++ b/lib/humaans/resources/timesheet_entry.ex
@@ -1,0 +1,29 @@
+defmodule Humaans.Resources.TimesheetEntry do
+  @moduledoc """
+  Representation of a Timesheet Entry resource.
+  """
+
+  defstruct [
+    :id,
+    :person_id,
+    :date,
+    :start_time,
+    :end_time,
+    :duration,
+    :created_at,
+    :updated_at
+  ]
+
+  use ExConstructor
+
+  @type t :: %__MODULE__{
+          id: binary,
+          person_id: binary,
+          date: binary,
+          start_time: binary,
+          end_time: binary,
+          duration: %{hours: integer, minutes: integer} | nil,
+          created_at: binary,
+          updated_at: binary
+        }
+end

--- a/lib/humaans/timesheet_entries.ex
+++ b/lib/humaans/timesheet_entries.ex
@@ -1,0 +1,76 @@
+defmodule Humaans.TimesheetEntries do
+  @moduledoc """
+  Handles operations related to timesheet entries.
+  """
+
+  alias Humaans.Resources.TimesheetEntry
+
+  @type delete_response :: {:ok, %{id: String.t(), deleted: bool()}} | {:error, any()}
+  @type list_response :: {:ok, [%TimesheetEntry{}]} | {:error, any()}
+  @type response :: {:ok, %TimesheetEntry{}} | {:error, any()}
+
+  @callback list(map()) :: {:ok, map()} | {:error, any()}
+  @callback create(map()) :: {:ok, map()} | {:error, any()}
+  @callback retrieve(String.t()) :: {:ok, map()} | {:error, any()}
+  @callback update(String.t(), map()) :: {:ok, map()} | {:error, any()}
+  @callback delete(String.t()) :: {:ok, map()} | {:error, any()}
+
+  @client Application.compile_env!(:humaans, :client)
+
+  @spec list(params :: keyword()) :: list_response()
+  def list(params \\ %{}) do
+    @client.get("/timesheet-entries", params)
+    |> handle_response()
+  end
+
+  @spec create(params :: keyword()) :: response()
+  def create(params) do
+    @client.post("/timesheet-entries", params)
+    |> handle_response()
+  end
+
+  @spec retrieve(id :: String.t()) :: response()
+  def retrieve(id) do
+    @client.get("/timesheet-entries/#{id}")
+    |> handle_response()
+  end
+
+  @spec update(id :: String.t(), params :: keyword()) :: response()
+  def update(id, params) do
+    @client.patch("/timesheet-entries/#{id}", params)
+    |> handle_response()
+  end
+
+  @spec delete(id :: String.t()) :: delete_response()
+  def delete(id) do
+    @client.delete("/timesheet-entries/#{id}")
+    |> handle_response()
+  end
+
+  defp handle_response({:ok, %{status: status, body: %{"data" => data}}})
+       when status in 200..299 do
+    {_r, response} =
+      Enum.map_reduce(data, [], fn i, acc ->
+        {TimesheetEntry.new(i), [TimesheetEntry.new(i) | acc]}
+      end)
+
+    {:ok, response}
+  end
+
+  defp handle_response({:ok, %{status: status, body: %{"deleted" => deleted, "id" => id}}})
+       when status in 200..299 do
+    {:ok, %{deleted: deleted, id: id}}
+  end
+
+  defp handle_response({:ok, %{status: status, body: body}}) when status in 200..299 do
+    response = TimesheetEntry.new(body)
+
+    {:ok, response}
+  end
+
+  defp handle_response({:ok, %{status: status, body: body}}) do
+    {:error, {status, body}}
+  end
+
+  defp handle_response({:error, _} = error), do: error
+end

--- a/test/humaans/timesheet_entries_test.exs
+++ b/test/humaans/timesheet_entries_test.exs
@@ -1,0 +1,210 @@
+defmodule Humaans.TimesheetEntriesTest do
+  use ExUnit.Case, async: true
+  import Mox
+
+  doctest Humaans.TimesheetEntries
+
+  setup :verify_on_exit!
+
+  describe "list/1" do
+    test "returns a list of timesheet submissions" do
+      expect(Humaans.MockClient, :get, fn path, _params ->
+        assert path == "/timesheet-entries"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "total" => 1,
+             "limit" => 100,
+             "skip" => 0,
+             "data" => [
+               %{
+                 "id" => "0vUGk85FkSDHXfeOTnXqkk4d",
+                 "personId" => "IL3vneCYhIx0xrR6um2sy2nW",
+                 "date" => "2020-04-01",
+                 "startTime" => "09:00:00",
+                 "endTime" => "12:30:00",
+                 "duration" => %{
+                   "hours" => 127,
+                   "minutes" => 30
+                 },
+                 "createdAt" => "2020-01-28T08:44:42.000Z",
+                 "updatedAt" => "2020-01-29T14:52:21.000Z"
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, list} = Humaans.TimesheetEntries.list()
+      assert is_list(list)
+      assert length(list) == 1
+
+      response = List.first(list)
+
+      assert response.id == "0vUGk85FkSDHXfeOTnXqkk4d"
+      assert response.person_id == "IL3vneCYhIx0xrR6um2sy2nW"
+      assert response.date == "2020-04-01"
+      assert response.start_time == "09:00:00"
+      assert response.end_time == "12:30:00"
+
+      assert response.duration == %{
+               "hours" => 127,
+               "minutes" => 30
+             }
+
+      assert response.created_at == "2020-01-28T08:44:42.000Z"
+      assert response.updated_at == "2020-01-29T14:52:21.000Z"
+    end
+
+    test "returns error when resource is not found" do
+      expect(Humaans.MockClient, :get, fn _path, _params ->
+        {:ok, %{status: 404, body: %{"error" => "Timesheet Entry not found"}}}
+      end)
+
+      assert {:error, {404, %{"error" => "Timesheet Entry not found"}}} ==
+               Humaans.TimesheetEntries.list()
+    end
+
+    test "returns error when request fails" do
+      expect(Humaans.MockClient, :get, fn _path, _params ->
+        {:error, "something unexpected happened"}
+      end)
+
+      assert {:error, "something unexpected happened"} ==
+               Humaans.TimesheetEntries.list()
+    end
+  end
+
+  describe "create/1" do
+    test "creates a new timesheet submission" do
+      params = %{personId: "IL3vneCYhIx0xrR6um2sy2nW", date: "2020-04-01", startTime: "09:00:00"}
+
+      expect(Humaans.MockClient, :post, fn path, ^params ->
+        assert path == "/timesheet-entries"
+
+        {:ok,
+         %{
+           status: 201,
+           body:
+             params
+             |> Map.put("id", "new_id")
+             |> Map.put("created_at", "2020-01-28T08:44:42.000Z")
+             |> Map.put("updated_at", "2020-01-29T14:52:21.000Z")
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.TimesheetEntries.create(params)
+      assert response.id == "new_id"
+      assert response.person_id == "IL3vneCYhIx0xrR6um2sy2nW"
+      assert response.date == "2020-04-01"
+      assert response.start_time == "09:00:00"
+      assert response.created_at == "2020-01-28T08:44:42.000Z"
+      assert response.updated_at == "2020-01-29T14:52:21.000Z"
+    end
+  end
+
+  describe "retrieve/1" do
+    test "retrieves a timesheet submission" do
+      expect(Humaans.MockClient, :get, fn path ->
+        assert path == "/timesheet-entries/0vUGk85FkSDHXfeOTnXqkk4d"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "0vUGk85FkSDHXfeOTnXqkk4d",
+             "personId" => "IL3vneCYhIx0xrR6um2sy2nW",
+             "date" => "2020-04-01",
+             "startTime" => "09:00:00",
+             "endTime" => "12:30:00",
+             "duration" => %{
+               "hours" => 127,
+               "minutes" => 30
+             },
+             "createdAt" => "2020-01-28T08:44:42.000Z",
+             "updatedAt" => "2020-01-29T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.TimesheetEntries.retrieve("0vUGk85FkSDHXfeOTnXqkk4d")
+      assert response.id == "0vUGk85FkSDHXfeOTnXqkk4d"
+      assert response.person_id == "IL3vneCYhIx0xrR6um2sy2nW"
+      assert response.person_id == "IL3vneCYhIx0xrR6um2sy2nW"
+      assert response.date == "2020-04-01"
+      assert response.start_time == "09:00:00"
+      assert response.end_time == "12:30:00"
+      assert response.created_at == "2020-01-28T08:44:42.000Z"
+      assert response.updated_at == "2020-01-29T14:52:21.000Z"
+
+      assert response.duration == %{
+               "hours" => 127,
+               "minutes" => 30
+             }
+
+      assert response.created_at == "2020-01-28T08:44:42.000Z"
+      assert response.updated_at == "2020-01-29T14:52:21.000Z"
+    end
+  end
+
+  describe "update/2" do
+    test "updates a timesheet submission" do
+      params = %{status: "pending"}
+
+      expect(Humaans.MockClient, :patch, fn path, ^params ->
+        assert path == "/timesheet-entries/0vUGk85FkSDHXfeOTnXqkk4d"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "0vUGk85FkSDHXfeOTnXqkk4d",
+             "personId" => "IL3vneCYhIx0xrR6um2sy2nW",
+             "date" => "2020-04-01",
+             "startTime" => "09:00:00",
+             "endTime" => "12:30:00",
+             "duration" => %{
+               "hours" => 3,
+               "minutes" => 30
+             },
+             "createdAt" => "2020-01-28T08:44:42.000Z",
+             "updatedAt" => "2020-01-29T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} =
+               Humaans.TimesheetEntries.update("0vUGk85FkSDHXfeOTnXqkk4d", params)
+
+      assert response.id == "0vUGk85FkSDHXfeOTnXqkk4d"
+      assert response.person_id == "IL3vneCYhIx0xrR6um2sy2nW"
+      assert response.date == "2020-04-01"
+      assert response.start_time == "09:00:00"
+      assert response.end_time == "12:30:00"
+
+      assert response.duration == %{
+               "hours" => 3,
+               "minutes" => 30
+             }
+
+      assert response.created_at == "2020-01-28T08:44:42.000Z"
+      assert response.updated_at == "2020-01-29T14:52:21.000Z"
+    end
+  end
+
+  describe "delete/1" do
+    test "deletes a timesheet submission" do
+      expect(Humaans.MockClient, :delete, fn path ->
+        assert path == "/timesheet-entries/Ivl8mvdLO8ux7T1h1DjGtClc"
+
+        {:ok, %{status: 200, body: %{"id" => "Ivl8mvdLO8ux7T1h1DjGtClc", "deleted" => true}}}
+      end)
+
+      assert {:ok, response} = Humaans.TimesheetEntries.delete("Ivl8mvdLO8ux7T1h1DjGtClc")
+      assert response.id == "Ivl8mvdLO8ux7T1h1DjGtClc"
+      assert response.deleted == true
+    end
+  end
+end


### PR DESCRIPTION
💁 These changes add support for the [Timesheet Entries API](https://docs.humaans.io/api/#timesheet-entries).