### PR TITLE
Elixir 1.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,13 +75,15 @@ jobs:
     strategy:
       matrix:
         otp: ['24', '25', '26', '27']
-        elixir: ['1.15', '1.16', '1.17']
+        elixir: ['1.15', '1.16', '1.17', '1.18']
         exclude:
           - elixir: '1.15'
             otp: '27'
           - elixir: '1.16'
             otp: '27'
           - elixir: '1.17'
+            otp: '24'
+          - elixir: '1.18'
             otp: '24'
 
     env:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.17-otp-27
+elixir 1.18-otp-27
 erlang 27.2


### PR DESCRIPTION
💁 These changes update the Elixir version used for local development to 1.18 and add it to the test matrix.