### PR TITLE
Provide default implementation for `Humaans.Client`

### DIFF
--- a/lib/humaans/client.ex
+++ b/lib/humaans/client.ex
@@ -3,7 +3,7 @@ defmodule Humaans.Client do
 
   alias Humaans.Response
 
-  @impl_module Application.compile_env!(:humaans, :client)
+  @impl_module Application.compile_env(:humaans, :client, Humaans.Client.Req)
 
   @callback delete(client :: map(), nonempty_binary()) :: Response.t()
   defdelegate delete(client, path), to: @impl_module

--- a/test/humaans/bank_accounts_test.exs
+++ b/test/humaans/bank_accounts_test.exs
@@ -6,10 +6,13 @@ defmodule Humaans.BankAccountsTest do
 
   setup :verify_on_exit!
 
-  describe "list/1" do
-    test "returns a list of bank accounts" do
-      client = %{req: Req.new()}
+  setup_all do
+    client = %{req: Req.new()}
+    [client: client]
+  end
 
+  describe "list/1" do
+    test "returns a list of bank accounts", %{client: client} do
       expect(Humaans.MockClient, :get, fn client_param, path, _params ->
         assert client_param == client
         assert path == "/bank-accounts"
@@ -53,9 +56,7 @@ defmodule Humaans.BankAccountsTest do
       assert hd(response).updated_at == "2020-01-29T14:52:21.000Z"
     end
 
-    test "returns error when resource is not found" do
-      client = %{req: Req.new()}
-
+    test "returns error when resource is not found", %{client: client} do
       expect(Humaans.MockClient, :get, fn client_param, _path, _params ->
         assert client_param == client
         {:ok, %{status: 404, body: %{"error" => "Bank Account not found"}}}
@@ -65,9 +66,7 @@ defmodule Humaans.BankAccountsTest do
                Humaans.BankAccounts.list(client)
     end
 
-    test "returns error when request fails" do
-      client = %{req: Req.new()}
-
+    test "returns error when request fails", %{client: client} do
       expect(Humaans.MockClient, :get, fn client_param, _path, _params ->
         assert client_param == client
         {:error, "something unexpected happened"}
@@ -79,9 +78,7 @@ defmodule Humaans.BankAccountsTest do
   end
 
   describe "create/1" do
-    test "creates a new bank account" do
-      client = %{req: Req.new()}
-
+    test "creates a new bank account", %{client: client} do
       params = %{
         "personId" => "123",
         "bankName" => "New Bank",
@@ -107,9 +104,7 @@ defmodule Humaans.BankAccountsTest do
   end
 
   describe "retrieve/1" do
-    test "retrieves a bank account" do
-      client = %{req: Req.new()}
-
+    test "retrieves a bank account", %{client: client} do
       expect(Humaans.MockClient, :get, fn client_param, path ->
         assert client_param == client
         assert path == "/bank-accounts/Ivl8mvdLO8ux7T1h1DjGtClc"
@@ -147,8 +142,7 @@ defmodule Humaans.BankAccountsTest do
   end
 
   describe "update/2" do
-    test "updates a bank account" do
-      client = %{req: Req.new()}
+    test "updates a bank account", %{client: client} do
       params = %{"bankName" => "N1"}
 
       expect(Humaans.MockClient, :patch, fn client_param, path, ^params ->
@@ -190,9 +184,7 @@ defmodule Humaans.BankAccountsTest do
   end
 
   describe "delete/1" do
-    test "deletes a bank account" do
-      client = %{req: Req.new()}
-
+    test "deletes a bank account", %{client: client} do
       expect(Humaans.MockClient, :delete, fn client_param, path ->
         assert client_param == client
         assert path == "/bank-accounts/Ivl8mvdLO8ux7T1h1DjGtClc"

--- a/test/humaans/companies_test.exs
+++ b/test/humaans/companies_test.exs
@@ -6,10 +6,13 @@ defmodule Humaans.CompaniesTest do
 
   setup :verify_on_exit!
 
-  describe "list/1" do
-    test "returns a list of companies" do
-      client = %{req: Req.new()}
+  setup_all do
+    client = %{req: Req.new()}
+    [client: client]
+  end
 
+  describe "list/1" do
+    test "returns a list of companies", %{client: client} do
       expect(Humaans.MockClient, :get, fn client_param, path, _params ->
         assert client_param == client
         assert path == "/companies"
@@ -53,9 +56,7 @@ defmodule Humaans.CompaniesTest do
       assert hd(response).updated_at == "2020-01-29T14:52:21.000Z"
     end
 
-    test "returns error when resource is not found" do
-      client = %{req: Req.new()}
-
+    test "returns error when resource is not found", %{client: client} do
       expect(Humaans.MockClient, :get, fn client_param, _path, _params ->
         assert client_param == client
         {:ok, %{status: 404, body: %{"error" => "Company not found"}}}
@@ -65,9 +66,7 @@ defmodule Humaans.CompaniesTest do
                Humaans.Companies.list(client)
     end
 
-    test "returns error when request fails" do
-      client = %{req: Req.new()}
-
+    test "returns error when request fails", %{client: client} do
       expect(Humaans.MockClient, :get, fn client_param, _path, _params ->
         assert client_param == client
         {:error, "something unexpected happened"}
@@ -79,9 +78,7 @@ defmodule Humaans.CompaniesTest do
   end
 
   describe "retrieve/1" do
-    test "retrieves a company" do
-      client = %{req: Req.new()}
-
+    test "retrieves a company", %{client: client} do
       expect(Humaans.MockClient, :get, fn client_param, path ->
         assert client_param == client
         assert path == "/companies/123"
@@ -119,8 +116,7 @@ defmodule Humaans.CompaniesTest do
   end
 
   describe "update/2" do
-    test "updates a company" do
-      client = %{req: Req.new()}
+    test "updates a company", %{client: client} do
       params = %{"name" => "Meac"}
 
       expect(Humaans.MockClient, :patch, fn client_param, path, ^params ->

--- a/test/humaans/compensation_types_test.exs
+++ b/test/humaans/compensation_types_test.exs
@@ -6,10 +6,13 @@ defmodule Humaans.CompensationTypesTest do
 
   setup :verify_on_exit!
 
-  describe "list/1" do
-    test "returns a list of compensation types" do
-      client = %{req: Req.new()}
+  setup_all do
+    client = %{req: Req.new()}
+    [client: client]
+  end
 
+  describe "list/1" do
+    test "returns a list of compensation types", %{client: client} do
       expect(Humaans.MockClient, :get, fn client_param, path, _params ->
         assert client_param == client
         assert path == "/compensation-types"
@@ -45,9 +48,7 @@ defmodule Humaans.CompensationTypesTest do
       assert hd(response).updated_at == "2020-01-29T14:52:21.000Z"
     end
 
-    test "returns error when resource is not found" do
-      client = %{req: Req.new()}
-
+    test "returns error when resource is not found", %{client: client} do
       expect(Humaans.MockClient, :get, fn client_param, _path, _params ->
         assert client_param == client
         {:ok, %{status: 404, body: %{"error" => "Compensation Type not found"}}}
@@ -57,9 +58,7 @@ defmodule Humaans.CompensationTypesTest do
                Humaans.CompensationTypes.list(client)
     end
 
-    test "returns error when request fails" do
-      client = %{req: Req.new()}
-
+    test "returns error when request fails", %{client: client} do
       expect(Humaans.MockClient, :get, fn client_param, _path, _params ->
         assert client_param == client
         {:error, "something unexpected happened"}
@@ -71,9 +70,7 @@ defmodule Humaans.CompensationTypesTest do
   end
 
   describe "create/1" do
-    test "creates a new compensation type" do
-      client = %{req: Req.new()}
-
+    test "creates a new compensation type", %{client: client} do
       params = %{
         "name" => "Salary"
       }
@@ -107,9 +104,7 @@ defmodule Humaans.CompensationTypesTest do
   end
 
   describe "retrieve/1" do
-    test "retrieves a compensation type" do
-      client = %{req: Req.new()}
-
+    test "retrieves a compensation type", %{client: client} do
       expect(Humaans.MockClient, :get, fn client_param, path ->
         assert client_param == client
         assert path == "/compensation-types/ldOQU3pLI5i8Y9k2rJbrXbFc"
@@ -141,8 +136,7 @@ defmodule Humaans.CompensationTypesTest do
   end
 
   describe "update/2" do
-    test "updates a compensation type" do
-      client = %{req: Req.new()}
+    test "updates a compensation type", %{client: client} do
       params = %{"name" => "New Salary"}
 
       expect(Humaans.MockClient, :patch, fn client_param, path, ^params ->
@@ -176,9 +170,7 @@ defmodule Humaans.CompensationTypesTest do
   end
 
   describe "delete/1" do
-    test "deletes a compensation type" do
-      client = %{req: Req.new()}
-
+    test "deletes a compensation type", %{client: client} do
       expect(Humaans.MockClient, :delete, fn client_param, path ->
         assert client_param == client
         assert path == "/compensation-types/ldOQU3pLI5i8Y9k2rJbrXbFc"

--- a/test/humaans/compensations_test.exs
+++ b/test/humaans/compensations_test.exs
@@ -6,10 +6,13 @@ defmodule Humaans.CompensationsTest do
 
   setup :verify_on_exit!
 
-  describe "list/1" do
-    test "returns a list of compensations" do
-      client = %{req: Req.new()}
+  setup_all do
+    client = %{req: Req.new()}
+    [client: client]
+  end
 
+  describe "list/1" do
+    test "returns a list of compensations", %{client: client} do
       expect(Humaans.MockClient, :get, fn client_param, path, _params ->
         assert client_param == client
         assert path == "/compensations"
@@ -57,9 +60,7 @@ defmodule Humaans.CompensationsTest do
       assert hd(response).updated_at == "2020-01-29T14:52:21.000Z"
     end
 
-    test "returns error when resource is not found" do
-      client = %{req: Req.new()}
-
+    test "returns error when resource is not found", %{client: client} do
       expect(Humaans.MockClient, :get, fn client_param, _path, _params ->
         assert client_param == client
         {:ok, %{status: 404, body: %{"error" => "Compensation not found"}}}
@@ -69,9 +70,7 @@ defmodule Humaans.CompensationsTest do
                Humaans.Compensations.list(client)
     end
 
-    test "returns error when request fails" do
-      client = %{req: Req.new()}
-
+    test "returns error when request fails", %{client: client} do
       expect(Humaans.MockClient, :get, fn client_param, _path, _params ->
         assert client_param == client
         {:error, "something unexpected happened"}
@@ -83,9 +82,7 @@ defmodule Humaans.CompensationsTest do
   end
 
   describe "create/1" do
-    test "creates a new compensation" do
-      client = %{req: Req.new()}
-
+    test "creates a new compensation", %{client: client} do
       params = %{
         personId: "IL3vneCYhIx0xrR6um2sy2nW",
         compensationTypeId: "aejf1oD4bZWNtEEnbFwrYGVg",
@@ -136,9 +133,7 @@ defmodule Humaans.CompensationsTest do
   end
 
   describe "retrieve/1" do
-    test "retrieves a compensation" do
-      client = %{req: Req.new()}
-
+    test "retrieves a compensation", %{client: client} do
       expect(Humaans.MockClient, :get, fn client_param, path ->
         assert client_param == client
         assert path == "/compensations/m54mmpqDwthFwiiMcY0ptJdz"
@@ -180,9 +175,7 @@ defmodule Humaans.CompensationsTest do
   end
 
   describe "update/2" do
-    test "updates a compensation" do
-      client = %{req: Req.new()}
-
+    test "updates a compensation", %{client: client} do
       params = %{
         compensationTypeId: "aejf1oD4bZWNtEEnbFwrYGVg",
         amount: "70000",
@@ -235,9 +228,7 @@ defmodule Humaans.CompensationsTest do
   end
 
   describe "delete/1" do
-    test "deletes a compensation" do
-      client = %{req: Req.new()}
-
+    test "deletes a compensation", %{client: client} do
       expect(Humaans.MockClient, :delete, fn client_param, path ->
         assert client_param == client
         assert path == "/compensations/m54mmpqDwthFwiiMcY0ptJdz"

--- a/test/humaans/people_test.exs
+++ b/test/humaans/people_test.exs
@@ -6,10 +6,13 @@ defmodule Humaans.PeopleTest do
 
   setup :verify_on_exit!
 
-  describe "list/1" do
-    test "returns a list of people" do
-      client = %{req: Req.new()}
+  setup_all do
+    client = %{req: Req.new()}
+    [client: client]
+  end
 
+  describe "list/1" do
+    test "returns a list of people", %{client: client} do
       expect(Humaans.MockClient, :get, fn client_param, path, _params ->
         assert client_param == client
         assert path == "/people"
@@ -202,9 +205,7 @@ defmodule Humaans.PeopleTest do
       assert hd(response).updated_at == "2020-01-29T14:52:21.000Z"
     end
 
-    test "returns error when resource is not found" do
-      client = %{req: Req.new()}
-
+    test "returns error when resource is not found", %{client: client} do
       expect(Humaans.MockClient, :get, fn client_param, _path, _params ->
         assert client_param == client
         {:ok, %{status: 404, body: %{"error" => "Person not found"}}}
@@ -214,9 +215,7 @@ defmodule Humaans.PeopleTest do
                Humaans.People.list(client)
     end
 
-    test "returns error when request fails" do
-      client = %{req: Req.new()}
-
+    test "returns error when request fails", %{client: client} do
       expect(Humaans.MockClient, :get, fn client_param, _path, _params ->
         assert client_param == client
         {:error, "something unexpected happened"}
@@ -228,9 +227,7 @@ defmodule Humaans.PeopleTest do
   end
 
   describe "create/1" do
-    test "creates a new person" do
-      client = %{req: Req.new()}
-
+    test "creates a new person", %{client: client} do
       params = %{
         "firstName" => "Kelsey",
         "lastName" => "Wicks",
@@ -287,9 +284,7 @@ defmodule Humaans.PeopleTest do
   end
 
   describe "retrieve/1" do
-    test "retrieves a person" do
-      client = %{req: Req.new()}
-
+    test "retrieves a person", %{client: client} do
       expect(Humaans.MockClient, :get, fn client_param, path ->
         assert client_param == client
         assert path == "/people/Ivl8mvdLO8ux7T1h1DjGtClc"
@@ -476,8 +471,7 @@ defmodule Humaans.PeopleTest do
   end
 
   describe "update/2" do
-    test "updates a person" do
-      client = %{req: Req.new()}
+    test "updates a person", %{client: client} do
       params = %{"middleName" => "some middle name"}
 
       expect(Humaans.MockClient, :patch, fn client_param, path, ^params ->
@@ -619,9 +613,7 @@ defmodule Humaans.PeopleTest do
   end
 
   describe "delete/1" do
-    test "deletes a person" do
-      client = %{req: Req.new()}
-
+    test "deletes a person", %{client: client} do
       expect(Humaans.MockClient, :delete, fn client_param, path ->
         assert client_param == client
         assert path == "/people/Ivl8mvdLO8ux7T1h1DjGtClc"

--- a/test/humaans/timesheet_entries_test.exs
+++ b/test/humaans/timesheet_entries_test.exs
@@ -6,10 +6,13 @@ defmodule Humaans.TimesheetEntriesTest do
 
   setup :verify_on_exit!
 
-  describe "list/1" do
-    test "returns a list of timesheet submissions" do
-      client = %{req: Req.new()}
+  setup_all do
+    client = %{req: Req.new()}
+    [client: client]
+  end
 
+  describe "list/1" do
+    test "returns a list of timesheet submissions", %{client: client} do
       expect(Humaans.MockClient, :get, fn client_param, path, _params ->
         assert client_param == client
         assert path == "/timesheet-entries"
@@ -61,9 +64,7 @@ defmodule Humaans.TimesheetEntriesTest do
       assert response.updated_at == "2020-01-29T14:52:21.000Z"
     end
 
-    test "returns error when resource is not found" do
-      client = %{req: Req.new()}
-
+    test "returns error when resource is not found", %{client: client} do
       expect(Humaans.MockClient, :get, fn client_param, _path, _params ->
         assert client_param == client
         {:ok, %{status: 404, body: %{"error" => "Timesheet Entry not found"}}}
@@ -73,9 +74,7 @@ defmodule Humaans.TimesheetEntriesTest do
                Humaans.TimesheetEntries.list(client)
     end
 
-    test "returns error when request fails" do
-      client = %{req: Req.new()}
-
+    test "returns error when request fails", %{client: client} do
       expect(Humaans.MockClient, :get, fn client_param, _path, _params ->
         assert client_param == client
         {:error, "something unexpected happened"}
@@ -87,8 +86,7 @@ defmodule Humaans.TimesheetEntriesTest do
   end
 
   describe "create/1" do
-    test "creates a new timesheet submission" do
-      client = %{req: Req.new()}
+    test "creates a new timesheet submission", %{client: client} do
       params = %{personId: "IL3vneCYhIx0xrR6um2sy2nW", date: "2020-04-01", startTime: "09:00:00"}
 
       expect(Humaans.MockClient, :post, fn client_param, path, ^params ->
@@ -117,9 +115,7 @@ defmodule Humaans.TimesheetEntriesTest do
   end
 
   describe "retrieve/1" do
-    test "retrieves a timesheet submission" do
-      client = %{req: Req.new()}
-
+    test "retrieves a timesheet submission", %{client: client} do
       expect(Humaans.MockClient, :get, fn client_param, path ->
         assert client_param == client
         assert path == "/timesheet-entries/0vUGk85FkSDHXfeOTnXqkk4d"
@@ -166,8 +162,7 @@ defmodule Humaans.TimesheetEntriesTest do
   end
 
   describe "update/2" do
-    test "updates a timesheet submission" do
-      client = %{req: Req.new()}
+    test "updates a timesheet submission", %{client: client} do
       params = %{status: "pending"}
 
       expect(Humaans.MockClient, :patch, fn client_param, path, ^params ->
@@ -213,9 +208,7 @@ defmodule Humaans.TimesheetEntriesTest do
   end
 
   describe "delete/1" do
-    test "deletes a timesheet submission" do
-      client = %{req: Req.new()}
-
+    test "deletes a timesheet submission", %{client: client} do
       expect(Humaans.MockClient, :delete, fn client_param, path ->
         assert client_param == client
         assert path == "/timesheet-entries/Ivl8mvdLO8ux7T1h1DjGtClc"

--- a/test/humaans/timesheet_submissions_test.exs
+++ b/test/humaans/timesheet_submissions_test.exs
@@ -6,10 +6,13 @@ defmodule Humaans.TimesheetSubmissionsTest do
 
   setup :verify_on_exit!
 
-  describe "list/1" do
-    test "returns a list of timesheet submissions" do
-      client = %{req: Req.new()}
+  setup_all do
+    client = %{req: Req.new()}
+    [client: client]
+  end
 
+  describe "list/1" do
+    test "returns a list of timesheet submissions", %{client: client} do
       expect(Humaans.MockClient, :get, fn client_param, path, _params ->
         assert client_param == client
         assert path == "/timesheet-submissions"
@@ -67,9 +70,7 @@ defmodule Humaans.TimesheetSubmissionsTest do
       assert hd(response).updated_at == "2020-01-29T14:52:21.000Z"
     end
 
-    test "returns error when resource is not found" do
-      client = %{req: Req.new()}
-
+    test "returns error when resource is not found", %{client: client} do
       expect(Humaans.MockClient, :get, fn client_param, _path, _params ->
         assert client_param == client
         {:ok, %{status: 404, body: %{"error" => "Timesheet Submission not found"}}}
@@ -79,9 +80,7 @@ defmodule Humaans.TimesheetSubmissionsTest do
                Humaans.TimesheetSubmissions.list(client)
     end
 
-    test "returns error when request fails" do
-      client = %{req: Req.new()}
-
+    test "returns error when request fails", %{client: client} do
       expect(Humaans.MockClient, :get, fn client_param, _path, _params ->
         assert client_param == client
         {:error, "something unexpected happened"}
@@ -93,8 +92,7 @@ defmodule Humaans.TimesheetSubmissionsTest do
   end
 
   describe "create/1" do
-    test "creates a new timesheet submission" do
-      client = %{req: Req.new()}
+    test "creates a new timesheet submission", %{client: client} do
       params = %{personId: "IL3vneCYhIx0xrR6um2sy2nW", startDate: "2020-04-01"}
 
       expect(Humaans.MockClient, :post, fn client_param, path, ^params ->
@@ -122,9 +120,7 @@ defmodule Humaans.TimesheetSubmissionsTest do
   end
 
   describe "retrieve/1" do
-    test "retrieves a timesheet submission" do
-      client = %{req: Req.new()}
-
+    test "retrieves a timesheet submission", %{client: client} do
       expect(Humaans.MockClient, :get, fn client_param, path ->
         assert client_param == client
         assert path == "/timesheet-submissions/Ivl8mvdLO8ux7T1h1DjGtClc"
@@ -178,8 +174,7 @@ defmodule Humaans.TimesheetSubmissionsTest do
   end
 
   describe "update/2" do
-    test "updates a timesheet submission" do
-      client = %{req: Req.new()}
+    test "updates a timesheet submission", %{client: client} do
       params = %{status: "pending"}
 
       expect(Humaans.MockClient, :patch, fn client_param, path, ^params ->
@@ -235,9 +230,7 @@ defmodule Humaans.TimesheetSubmissionsTest do
   end
 
   describe "delete/1" do
-    test "deletes a timesheet submission" do
-      client = %{req: Req.new()}
-
+    test "deletes a timesheet submission", %{client: client} do
       expect(Humaans.MockClient, :delete, fn client_param, path ->
         assert client_param == client
         assert path == "/timesheet-submissions/Ivl8mvdLO8ux7T1h1DjGtClc"

--- a/test/humaans_test.exs
+++ b/test/humaans_test.exs
@@ -1,5 +1,5 @@
 defmodule HumaansTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   doctest Humaans
 


### PR DESCRIPTION
💁 Without a default implementation module, consumers of this project must define a value for `[humaans: [:client]]` in their application's configuration which will invariably lead to breakage when using it for the first time. These changes resolve this by providing a sane default value. I've also refactored some of the tests.