### PR TITLE
HexDocs: enhancements to documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         restore-keys: ${{ runner.os }}-${{ steps.setup-beam.otp-version }}-${{ steps.setup-beam.elixir-version }}-
     - name: Install and compile dependencies
       if: steps.cache-deps.outputs.cache-hit != 'true'
-      run: mix do deps.get --only test, deps.compile
+      run: mix do deps.get --only ${{ env.MIX_ENV }}, deps.compile
     - name: Check code format
       run: mix format --check-formatted
 
@@ -108,7 +108,7 @@ jobs:
         restore-keys: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-
     - name: Install and compile dependencies
       if: steps.cache-deps.outputs.cache-hit != 'true'
-      run: mix do deps.get --only test, deps.compile
+      run: mix do deps.get --only ${{ env.MIX_ENV }}, deps.compile
     - name: Compile code
       run: mix compile
     - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,36 @@ jobs:
     - name: Check for unused dependencies
       run: mix deps.unlock --check-unused
 
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+
+    env:
+      MIX_ENV: dev
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Elixir
+      id: setup-beam
+      uses: erlef/setup-beam@v1
+      with:
+        version-file: '.tool-versions'
+        version-type: 'strict'
+    - name: Cache dependencies
+      id: cache-deps
+      uses: actions/cache@v4
+      with:
+        path: |
+          _build
+          deps
+        key: ${{ runner.os }}-${{ env.MIX_ENV }}-${{ steps.setup-beam.otp-version }}-${{ steps.setup-beam.elixir-version }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: ${{ runner.os }}-${{ env.MIX_ENV }}-${{ steps.setup-beam.otp-version }}-${{ steps.setup-beam.elixir-version }}-
+    - name: Install and compile dependencies
+      if: steps.cache-deps.outputs.cache-hit != 'true'
+      run: mix do deps.get --only ${{ env.MIX_ENV }}, deps.compile
+    - name: Generate documentation
+      run: mix docs --warnings-as-errors
+
   formatting:
     name: Formatting
     runs-on: ubuntu-latest

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule Humaans.MixProject do
       source_url: @repo_url,
       homepage_url: @repo_url,
       docs: [
-        main: "Humaans",
+        main: "readme",
         source_ref: "v#{@version}",
         source_url: @repo_url,
         extras: ["LICENSE", "README.md"]

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule Humaans.MixProject do
         main: "readme",
         source_ref: "v#{@version}",
         source_url: @repo_url,
-        extras: ["LICENSE", "README.md"]
+        extras: ["README.md", "CHANGELOG.md", "LICENSE"]
       ]
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -19,9 +19,13 @@ defmodule Humaans.MixProject do
 
       # Docs
       name: "Humaans",
+      source_url: @repo_url,
+      homepage_url: @repo_url,
       docs: [
+        main: "Humaans",
         source_ref: "v#{@version}",
-        source_url: @repo_url
+        source_url: @repo_url,
+        extras: ["README.md"]
       ]
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -21,12 +21,7 @@ defmodule Humaans.MixProject do
       name: "Humaans",
       source_url: @repo_url,
       homepage_url: @repo_url,
-      docs: [
-        main: "readme",
-        source_ref: "v#{@version}",
-        source_url: @repo_url,
-        extras: ["README.md", "CHANGELOG.md", "LICENSE"]
-      ]
+      docs: docs()
     ]
   end
 
@@ -53,6 +48,15 @@ defmodule Humaans.MixProject do
     [
       licenses: ["MIT"],
       links: %{"GitHub" => @repo_url}
+    ]
+  end
+
+  defp docs do
+    [
+      main: "readme",
+      source_ref: "v#{@version}",
+      source_url: @repo_url,
+      extras: ["README.md", "CHANGELOG.md", "LICENSE"]
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule Humaans.MixProject do
         main: "Humaans",
         source_ref: "v#{@version}",
         source_url: @repo_url,
-        extras: ["README.md"]
+        extras: ["LICENSE", "README.md"]
       ]
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -47,7 +47,10 @@ defmodule Humaans.MixProject do
   defp package do
     [
       licenses: ["MIT"],
-      links: %{"GitHub" => @repo_url}
+      links: %{
+        "GitHub" => @repo_url,
+        "Changelog" => "https://hexdocs.pm/humaans/changelog.html"
+      }
     ]
   end
 


### PR DESCRIPTION
💁 These changes enhance the existing `ex_doc` configuration to improve the presentation on [HexDocs](https://hexdocs.pm/):
- name the project via `docs.main`
- set the source and homepage URLs
- add the README via `docs.extras[]`

I've also added another job to the existing CI workflow to validate that the package documentation will be generated without errors or warnings.