### PR TITLE
CI: There can be only one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
   required:
     name: Required
     needs: [dependencies, docs, formatting, test]
+    runs-on: ubuntu-latest
 
     steps:
       - name: Status of workflow jobs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,14 @@ permissions:
   contents: read
 
 jobs:
+  required:
+    name: Required
+    needs: [dependencies, docs, formatting, test]
+
+    steps:
+      - name: Status of workflow jobs
+        run: echo 'All jobs in this workflow have successfully run'
+
   dependencies:
     name: Dependencies
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,8 @@ jobs:
       uses: actions/cache@v4
       with:
         path: deps
-        key: deps-${{ runner.os }}-${{ steps.setup-beam.otp-version }}-${{ steps.setup-beam.elixir-version }}-${{ hashFiles('**/mix.lock') }}
-        restore-keys: deps-${{ runner.os }}-${{ steps.setup-beam.otp-version }}-${{ steps.setup-beam.elixir-version }}-
+        key: deps-${{ runner.os }}-${{ steps.setup-beam.outputs.otp-version }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: deps-${{ runner.os }}-${{ steps.setup-beam.outputs.otp-version }}-${{ steps.setup-beam.outputs.elixir-version }}-
     - name: Install and compile dependencies
       if: steps.cache-deps.outputs.cache-hit != 'true'
       run: mix deps.get
@@ -70,8 +70,8 @@ jobs:
         path: |
           _build
           deps
-        key: ${{ runner.os }}-${{ env.MIX_ENV }}-${{ steps.setup-beam.otp-version }}-${{ steps.setup-beam.elixir-version }}-${{ hashFiles('**/mix.lock') }}
-        restore-keys: ${{ runner.os }}-${{ env.MIX_ENV }}-${{ steps.setup-beam.otp-version }}-${{ steps.setup-beam.elixir-version }}-
+        key: ${{ runner.os }}-${{ env.MIX_ENV }}-${{ steps.setup-beam.outputs.otp-version }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: ${{ runner.os }}-${{ env.MIX_ENV }}-${{ steps.setup-beam.outputs.otp-version }}-${{ steps.setup-beam.outputs.elixir-version }}-
     - name: Install and compile dependencies
       if: steps.cache-deps.outputs.cache-hit != 'true'
       run: mix do deps.get --only ${{ env.MIX_ENV }}, deps.compile
@@ -100,8 +100,8 @@ jobs:
         path: |
           _build
           deps
-        key: ${{ runner.os }}-${{ steps.setup-beam.otp-version }}-${{ steps.setup-beam.elixir-version }}-${{ hashFiles('**/mix.lock') }}
-        restore-keys: ${{ runner.os }}-${{ steps.setup-beam.otp-version }}-${{ steps.setup-beam.elixir-version }}-
+        key: ${{ runner.os }}-${{ steps.setup-beam.outputs.otp-version }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: ${{ runner.os }}-${{ steps.setup-beam.outputs.otp-version }}-${{ steps.setup-beam.outputs.elixir-version }}-
     - name: Install and compile dependencies
       if: steps.cache-deps.outputs.cache-hit != 'true'
       run: mix do deps.get --only ${{ env.MIX_ENV }}, deps.compile


### PR DESCRIPTION
💁 GitHub allows workflow jobs to be configured as required to pass prior to merge. Instead of configuring this individually at the job level, this change uses a different approach by transparently configuring jobs as "needed" within the workflow itself.