### PR TITLE
Introduce `ResponseHandler`

### DIFF
--- a/lib/humaans/bank_accounts.ex
+++ b/lib/humaans/bank_accounts.ex
@@ -4,7 +4,7 @@ defmodule Humaans.BankAccounts do
   Humaans API.
   """
 
-  alias Humaans.{Client, Resources.BankAccount}
+  alias Humaans.{Client, Resources.BankAccount, ResponseHandler}
 
   @type delete_response :: {:ok, %{id: String.t(), deleted: bool()}} | {:error, any()}
   @type list_response :: {:ok, [%BankAccount{}]} | {:error, any()}
@@ -40,7 +40,7 @@ defmodule Humaans.BankAccounts do
   @spec list(client :: map(), params :: keyword()) :: list_response()
   def list(client, params \\ %{}) do
     Client.get(client, "/bank-accounts", params)
-    |> handle_response()
+    |> ResponseHandler.handle_list_response(BankAccount)
   end
 
   @doc """
@@ -69,7 +69,7 @@ defmodule Humaans.BankAccounts do
   @spec create(client :: map(), params :: keyword()) :: response()
   def create(client, params) do
     Client.post(client, "/bank-accounts", params)
-    |> handle_response()
+    |> ResponseHandler.handle_resource_response(BankAccount)
   end
 
   @doc """
@@ -90,7 +90,7 @@ defmodule Humaans.BankAccounts do
   @spec retrieve(client :: map(), id :: String.t()) :: response()
   def retrieve(client, id) do
     Client.get(client, "/bank-accounts/#{id}")
-    |> handle_response()
+    |> ResponseHandler.handle_resource_response(BankAccount)
   end
 
   @doc """
@@ -114,7 +114,7 @@ defmodule Humaans.BankAccounts do
   @spec update(client :: map(), id :: String.t(), params :: keyword()) :: response()
   def update(client, id, params) do
     Client.patch(client, "/bank-accounts/#{id}", params)
-    |> handle_response()
+    |> ResponseHandler.handle_resource_response(BankAccount)
   end
 
   @doc """
@@ -136,33 +136,6 @@ defmodule Humaans.BankAccounts do
   @spec delete(client :: map(), id :: String.t()) :: delete_response()
   def delete(client, id) do
     Client.delete(client, "/bank-accounts/#{id}")
-    |> handle_response()
+    |> ResponseHandler.handle_delete_response()
   end
-
-  defp handle_response({:ok, %{status: status, body: %{"data" => data}}})
-       when status in 200..299 do
-    {_r, response} =
-      Enum.map_reduce(data, [], fn i, acc ->
-        {BankAccount.new(i), [BankAccount.new(i) | acc]}
-      end)
-
-    {:ok, response}
-  end
-
-  defp handle_response({:ok, %{status: status, body: %{"deleted" => deleted, "id" => id}}})
-       when status in 200..299 do
-    {:ok, %{deleted: deleted, id: id}}
-  end
-
-  defp handle_response({:ok, %{status: status, body: body}}) when status in 200..299 do
-    response = BankAccount.new(body)
-
-    {:ok, response}
-  end
-
-  defp handle_response({:ok, %{status: status, body: body}}) do
-    {:error, {status, body}}
-  end
-
-  defp handle_response({:error, _} = error), do: error
 end

--- a/lib/humaans/companies.ex
+++ b/lib/humaans/companies.ex
@@ -5,7 +5,7 @@ defmodule Humaans.Companies do
   retrieved, and updated, but not created or deleted through the API.
   """
 
-  alias Humaans.{Client, Resources.Company}
+  alias Humaans.{Client, Resources.Company, ResponseHandler}
 
   @type list_response :: {:ok, [%Company{}]} | {:error, any()}
   @type response :: {:ok, %Company{}} | {:error, any()}
@@ -38,7 +38,7 @@ defmodule Humaans.Companies do
   @spec list(client :: map(), params :: keyword()) :: list_response()
   def list(client, params \\ %{}) do
     Client.get(client, "/companies", params)
-    |> handle_response()
+    |> ResponseHandler.handle_list_response(Company)
   end
 
   @doc """
@@ -59,7 +59,7 @@ defmodule Humaans.Companies do
   @spec get(client :: map(), id :: String.t()) :: response()
   def get(client, id) do
     Client.get(client, "/companies/#{id}")
-    |> handle_response()
+    |> ResponseHandler.handle_resource_response(Company)
   end
 
   @doc """
@@ -83,28 +83,6 @@ defmodule Humaans.Companies do
   @spec update(client :: map(), id :: String.t(), params :: keyword()) :: response()
   def update(client, id, params) do
     Client.patch(client, "/companies/#{id}", params)
-    |> handle_response()
+    |> ResponseHandler.handle_resource_response(Company)
   end
-
-  defp handle_response({:ok, %{status: status, body: %{"data" => data}}})
-       when status in 200..299 do
-    {_r, response} =
-      Enum.map_reduce(data, [], fn i, acc ->
-        {Company.new(i), [Company.new(i) | acc]}
-      end)
-
-    {:ok, response}
-  end
-
-  defp handle_response({:ok, %{status: status, body: body}}) when status in 200..299 do
-    response = Company.new(body)
-
-    {:ok, response}
-  end
-
-  defp handle_response({:ok, %{status: status, body: body}}) do
-    {:error, {status, body}}
-  end
-
-  defp handle_response({:error, _} = error), do: error
 end

--- a/lib/humaans/compensation_types.ex
+++ b/lib/humaans/compensation_types.ex
@@ -5,7 +5,7 @@ defmodule Humaans.CompensationTypes do
   compensation such as salary, bonus, commission, etc.
   """
 
-  alias Humaans.{Client, Resources.CompensationType}
+  alias Humaans.{Client, Resources.CompensationType, ResponseHandler}
 
   @type delete_response :: {:ok, %{id: String.t(), deleted: bool()}} | {:error, any()}
   @type list_response :: {:ok, [%CompensationType{}]} | {:error, any()}
@@ -41,7 +41,7 @@ defmodule Humaans.CompensationTypes do
   @spec list(client :: map(), params :: keyword()) :: list_response()
   def list(client, params \\ %{}) do
     Client.get(client, "/compensation-types", params)
-    |> handle_response()
+    |> ResponseHandler.handle_list_response(CompensationType)
   end
 
   @doc """
@@ -69,7 +69,7 @@ defmodule Humaans.CompensationTypes do
   @spec create(client :: map(), params :: keyword()) :: response()
   def create(client, params) do
     Client.post(client, "/compensation-types", params)
-    |> handle_response()
+    |> ResponseHandler.handle_resource_response(CompensationType)
   end
 
   @doc """
@@ -90,7 +90,7 @@ defmodule Humaans.CompensationTypes do
   @spec retrieve(client :: map(), id :: String.t()) :: response()
   def retrieve(client, id) do
     Client.get(client, "/compensation-types/#{id}")
-    |> handle_response()
+    |> ResponseHandler.handle_resource_response(CompensationType)
   end
 
   @doc """
@@ -114,7 +114,7 @@ defmodule Humaans.CompensationTypes do
   @spec update(client :: map(), id :: String.t(), params :: keyword()) :: response()
   def update(client, id, params) do
     Client.patch(client, "/compensation-types/#{id}", params)
-    |> handle_response()
+    |> ResponseHandler.handle_resource_response(CompensationType)
   end
 
   @doc """
@@ -136,33 +136,6 @@ defmodule Humaans.CompensationTypes do
   @spec delete(client :: map(), id :: String.t()) :: delete_response()
   def delete(client, id) do
     Client.delete(client, "/compensation-types/#{id}")
-    |> handle_response()
+    |> ResponseHandler.handle_delete_response()
   end
-
-  defp handle_response({:ok, %{status: status, body: %{"data" => data}}})
-       when status in 200..299 do
-    {_r, response} =
-      Enum.map_reduce(data, [], fn i, acc ->
-        {CompensationType.new(i), [CompensationType.new(i) | acc]}
-      end)
-
-    {:ok, response}
-  end
-
-  defp handle_response({:ok, %{status: status, body: %{"deleted" => deleted, "id" => id}}})
-       when status in 200..299 do
-    {:ok, %{deleted: deleted, id: id}}
-  end
-
-  defp handle_response({:ok, %{status: status, body: body}}) when status in 200..299 do
-    response = CompensationType.new(body)
-
-    {:ok, response}
-  end
-
-  defp handle_response({:ok, %{status: status, body: body}}) do
-    {:error, {status, body}}
-  end
-
-  defp handle_response({:error, _} = error), do: error
 end

--- a/lib/humaans/compensations.ex
+++ b/lib/humaans/compensations.ex
@@ -6,7 +6,7 @@ defmodule Humaans.Compensations do
   bonus).
   """
 
-  alias Humaans.{Client, Resources.Compensation}
+  alias Humaans.{Client, Resources.Compensation, ResponseHandler}
 
   @type delete_response :: {:ok, %{id: String.t(), deleted: bool()}} | {:error, any()}
   @type list_response :: {:ok, [%Compensation{}]} | {:error, any()}
@@ -42,7 +42,7 @@ defmodule Humaans.Compensations do
   @spec list(client :: map(), params :: keyword()) :: list_response()
   def list(client, params \\ %{}) do
     Client.get(client, "/compensations", params)
-    |> handle_response()
+    |> ResponseHandler.handle_list_response(Compensation)
   end
 
   @doc """
@@ -72,7 +72,7 @@ defmodule Humaans.Compensations do
   @spec create(client :: map(), params :: keyword()) :: response()
   def create(client, params) do
     Client.post(client, "/compensations", params)
-    |> handle_response()
+    |> ResponseHandler.handle_resource_response(Compensation)
   end
 
   @doc """
@@ -93,7 +93,7 @@ defmodule Humaans.Compensations do
   @spec retrieve(client :: map(), id :: String.t()) :: response()
   def retrieve(client, id) do
     Client.get(client, "/compensations/#{id}")
-    |> handle_response()
+    |> ResponseHandler.handle_resource_response(Compensation)
   end
 
   @doc """
@@ -117,7 +117,7 @@ defmodule Humaans.Compensations do
   @spec update(client :: map(), id :: String.t(), params :: keyword()) :: response()
   def update(client, id, params) do
     Client.patch(client, "/compensations/#{id}", params)
-    |> handle_response()
+    |> ResponseHandler.handle_resource_response(Compensation)
   end
 
   @doc """
@@ -139,33 +139,6 @@ defmodule Humaans.Compensations do
   @spec delete(client :: map(), id :: String.t()) :: delete_response()
   def delete(client, id) do
     Client.delete(client, "/compensations/#{id}")
-    |> handle_response()
+    |> ResponseHandler.handle_delete_response()
   end
-
-  defp handle_response({:ok, %{status: status, body: %{"data" => data}}})
-       when status in 200..299 do
-    {response, _rest} =
-      Enum.map_reduce(data, [], fn i, acc ->
-        {Compensation.new(i), [Compensation.new(i) | acc]}
-      end)
-
-    {:ok, response}
-  end
-
-  defp handle_response({:ok, %{status: status, body: %{"deleted" => deleted, "id" => id}}})
-       when status in 200..299 do
-    {:ok, %{deleted: deleted, id: id}}
-  end
-
-  defp handle_response({:ok, %{status: status, body: body}}) when status in 200..299 do
-    response = Compensation.new(body)
-
-    {:ok, response}
-  end
-
-  defp handle_response({:ok, %{status: status, body: body}}) do
-    {:error, {status, body}}
-  end
-
-  defp handle_response({:error, _} = error), do: error
 end

--- a/lib/humaans/people.ex
+++ b/lib/humaans/people.ex
@@ -4,7 +4,7 @@ defmodule Humaans.People do
   API.
   """
 
-  alias Humaans.{Client, Resources.Person}
+  alias Humaans.{Client, Resources.Person, ResponseHandler}
 
   @type delete_response :: {:ok, %{id: String.t(), deleted: bool()}} | {:error, any()}
   @type list_response :: {:ok, [%Person{}]} | {:error, any()}
@@ -40,7 +40,7 @@ defmodule Humaans.People do
   @spec list(client :: map(), params :: keyword()) :: list_response()
   def list(client, params \\ %{}) do
     Client.get(client, "/people", params)
-    |> handle_response()
+    |> ResponseHandler.handle_list_response(Person)
   end
 
   @doc """
@@ -67,7 +67,7 @@ defmodule Humaans.People do
   @spec create(client :: map(), params :: keyword()) :: response()
   def create(client, params) do
     Client.post(client, "/people", params)
-    |> handle_response()
+    |> ResponseHandler.handle_resource_response(Person)
   end
 
   @doc """
@@ -88,7 +88,7 @@ defmodule Humaans.People do
   @spec retrieve(client :: map(), id :: String.t()) :: response()
   def retrieve(client, id) do
     Client.get(client, "/people/#{id}")
-    |> handle_response()
+    |> ResponseHandler.handle_resource_response(Person)
   end
 
   @doc """
@@ -112,7 +112,7 @@ defmodule Humaans.People do
   @spec update(client :: map(), id :: String.t(), params :: keyword()) :: response()
   def update(client, id, params) do
     Client.patch(client, "/people/#{id}", params)
-    |> handle_response()
+    |> ResponseHandler.handle_resource_response(Person)
   end
 
   @doc """
@@ -134,33 +134,6 @@ defmodule Humaans.People do
   @spec delete(client :: map(), id :: String.t()) :: delete_response()
   def delete(client, id) do
     Client.delete(client, "/people/#{id}")
-    |> handle_response()
+    |> ResponseHandler.handle_delete_response()
   end
-
-  defp handle_response({:ok, %{status: status, body: %{"data" => data}}})
-       when status in 200..299 do
-    {_r, response} =
-      Enum.map_reduce(data, [], fn i, acc ->
-        {Person.new(i), [Person.new(i) | acc]}
-      end)
-
-    {:ok, response}
-  end
-
-  defp handle_response({:ok, %{status: status, body: %{"deleted" => deleted, "id" => id}}})
-       when status in 200..299 do
-    {:ok, %{deleted: deleted, id: id}}
-  end
-
-  defp handle_response({:ok, %{status: status, body: body}}) when status in 200..299 do
-    response = Person.new(body)
-
-    {:ok, response}
-  end
-
-  defp handle_response({:ok, %{status: status, body: body}}) do
-    {:error, {status, body}}
-  end
-
-  defp handle_response({:error, _} = error), do: error
 end

--- a/lib/humaans/response_handler.ex
+++ b/lib/humaans/response_handler.ex
@@ -1,0 +1,109 @@
+defmodule Humaans.ResponseHandler do
+  @moduledoc """
+  This module provides helper functions for handling API responses consistently
+  across all Humaans API resource modules.
+  """
+
+  @doc """
+  Handles responses for list operations, converting raw API response data into a list of resource structs.
+
+  ## Parameters
+
+    * `response` - The response tuple from the HTTP client
+    * `resource_module` - The module to use for converting the raw data to structs
+
+  ## Examples
+
+      response = Client.get(client, "/endpoint", params)
+      ResponseHandler.handle_list_response(response, Resources.Person)
+
+  """
+  @spec handle_list_response({:ok, map()} | {:error, any()}, module()) ::
+          {:ok, [struct()]} | {:error, any()}
+  def handle_list_response(response, resource_module) do
+    handle_response(response, fn data ->
+      {_r, resources} =
+        Enum.map_reduce(data, [], fn item, acc ->
+          resource = resource_module.new(item)
+          {resource, [resource | acc]}
+        end)
+
+      resources
+    end)
+  end
+
+  @doc """
+  Handles responses for single resource operations, converting raw API response data into a resource struct.
+
+  ## Parameters
+
+    * `response` - The response tuple from the HTTP client
+    * `resource_module` - The module to use for converting the raw data to a struct
+
+  ## Examples
+
+      response = Client.get(client, "/endpoint/id")
+      ResponseHandler.handle_resource_response(response, Resources.Person)
+
+  """
+  @spec handle_resource_response({:ok, map()} | {:error, any()}, module()) ::
+          {:ok, struct()} | {:error, any()}
+  def handle_resource_response(response, resource_module) do
+    handle_response(response, fn body ->
+      resource_module.new(body)
+    end)
+  end
+
+  @doc """
+  Handles responses for delete operations, returning a map with deleted status and ID.
+
+  ## Parameters
+
+    * `response` - The response tuple from the HTTP client
+
+  ## Examples
+
+      response = Client.delete(client, "/endpoint/id")
+      ResponseHandler.handle_delete_response(response)
+
+  """
+  @spec handle_delete_response({:ok, map()} | {:error, any()}) ::
+          {:ok, %{deleted: boolean(), id: String.t()}} | {:error, any()}
+  def handle_delete_response(response) do
+    case response do
+      {:ok, %{status: status, body: %{"deleted" => deleted, "id" => id}}}
+      when status in 200..299 ->
+        {:ok, %{deleted: deleted, id: id}}
+
+      response ->
+        handle_response(response, fn _ -> nil end)
+    end
+  end
+
+  @doc """
+  Generic response handler for all API operations.
+
+  ## Parameters
+
+    * `response` - The response tuple from the HTTP client
+    * `success_handler` - A function to process successful response bodies
+
+  """
+  @spec handle_response({:ok, map()} | {:error, any()}, (any() -> any())) ::
+          {:ok, any()} | {:error, any()}
+  def handle_response(response, success_handler) do
+    case response do
+      {:ok, %{status: status, body: %{"data" => data}}} when status in 200..299 ->
+        {:ok, success_handler.(data)}
+
+      {:ok, %{status: status, body: body}} when status in 200..299 ->
+        {:ok, success_handler.(body)}
+
+      {:ok, %{status: status, body: body}} ->
+        {:error, {status, body}}
+
+      {:error, _} = error ->
+        error
+    end
+  end
+end

--- a/lib/humaans/timesheet_entries.ex
+++ b/lib/humaans/timesheet_entries.ex
@@ -5,7 +5,7 @@ defmodule Humaans.TimesheetEntries do
   such as hours worked on a specific date.
   """
 
-  alias Humaans.{Client, Resources.TimesheetEntry}
+  alias Humaans.{Client, Resources.TimesheetEntry, ResponseHandler}
 
   @type delete_response :: {:ok, %{id: String.t(), deleted: bool()}} | {:error, any()}
   @type list_response :: {:ok, [%TimesheetEntry{}]} | {:error, any()}
@@ -41,7 +41,7 @@ defmodule Humaans.TimesheetEntries do
   @spec list(client :: map(), params :: keyword()) :: list_response()
   def list(client, params \\ %{}) do
     Client.get(client, "/timesheet-entries", params)
-    |> handle_response()
+    |> ResponseHandler.handle_list_response(TimesheetEntry)
   end
 
   @doc """
@@ -69,7 +69,7 @@ defmodule Humaans.TimesheetEntries do
   @spec create(client :: map(), params :: keyword()) :: response()
   def create(client, params) do
     Client.post(client, "/timesheet-entries", params)
-    |> handle_response()
+    |> ResponseHandler.handle_resource_response(TimesheetEntry)
   end
 
   @doc """
@@ -90,7 +90,7 @@ defmodule Humaans.TimesheetEntries do
   @spec retrieve(client :: map(), id :: String.t()) :: response()
   def retrieve(client, id) do
     Client.get(client, "/timesheet-entries/#{id}")
-    |> handle_response()
+    |> ResponseHandler.handle_resource_response(TimesheetEntry)
   end
 
   @doc """
@@ -114,7 +114,7 @@ defmodule Humaans.TimesheetEntries do
   @spec update(client :: map(), id :: String.t(), params :: keyword()) :: response()
   def update(client, id, params) do
     Client.patch(client, "/timesheet-entries/#{id}", params)
-    |> handle_response()
+    |> ResponseHandler.handle_resource_response(TimesheetEntry)
   end
 
   @doc """
@@ -136,33 +136,6 @@ defmodule Humaans.TimesheetEntries do
   @spec delete(client :: map(), id :: String.t()) :: delete_response()
   def delete(client, id) do
     Client.delete(client, "/timesheet-entries/#{id}")
-    |> handle_response()
+    |> ResponseHandler.handle_delete_response()
   end
-
-  defp handle_response({:ok, %{status: status, body: %{"data" => data}}})
-       when status in 200..299 do
-    {_r, response} =
-      Enum.map_reduce(data, [], fn i, acc ->
-        {TimesheetEntry.new(i), [TimesheetEntry.new(i) | acc]}
-      end)
-
-    {:ok, response}
-  end
-
-  defp handle_response({:ok, %{status: status, body: %{"deleted" => deleted, "id" => id}}})
-       when status in 200..299 do
-    {:ok, %{deleted: deleted, id: id}}
-  end
-
-  defp handle_response({:ok, %{status: status, body: body}}) when status in 200..299 do
-    response = TimesheetEntry.new(body)
-
-    {:ok, response}
-  end
-
-  defp handle_response({:ok, %{status: status, body: body}}) do
-    {:error, {status, body}}
-  end
-
-  defp handle_response({:error, _} = error), do: error
 end

--- a/lib/humaans/timesheet_submissions.ex
+++ b/lib/humaans/timesheet_submissions.ex
@@ -6,7 +6,7 @@ defmodule Humaans.TimesheetSubmissions do
   approval.
   """
 
-  alias Humaans.{Client, Resources.TimesheetSubmission}
+  alias Humaans.{Client, Resources.TimesheetSubmission, ResponseHandler}
 
   @type delete_response :: {:ok, %{id: String.t(), deleted: bool()}} | {:error, any()}
   @type list_response :: {:ok, [%TimesheetSubmission{}]} | {:error, any()}
@@ -42,7 +42,7 @@ defmodule Humaans.TimesheetSubmissions do
   @spec list(client :: map(), params :: keyword()) :: list_response()
   def list(client, params \\ %{}) do
     Client.get(client, "/timesheet-submissions", params)
-    |> handle_response()
+    |> ResponseHandler.handle_list_response(TimesheetSubmission)
   end
 
   @doc """
@@ -70,7 +70,7 @@ defmodule Humaans.TimesheetSubmissions do
   @spec create(client :: map(), params :: keyword()) :: response()
   def create(client, params) do
     Client.post(client, "/timesheet-submissions", params)
-    |> handle_response()
+    |> ResponseHandler.handle_resource_response(TimesheetSubmission)
   end
 
   @doc """
@@ -91,7 +91,7 @@ defmodule Humaans.TimesheetSubmissions do
   @spec retrieve(client :: map(), id :: String.t()) :: response()
   def retrieve(client, id) do
     Client.get(client, "/timesheet-submissions/#{id}")
-    |> handle_response()
+    |> ResponseHandler.handle_resource_response(TimesheetSubmission)
   end
 
   @doc """
@@ -115,7 +115,7 @@ defmodule Humaans.TimesheetSubmissions do
   @spec update(client :: map(), id :: String.t(), params :: keyword()) :: response()
   def update(client, id, params) do
     Client.patch(client, "/timesheet-submissions/#{id}", params)
-    |> handle_response()
+    |> ResponseHandler.handle_resource_response(TimesheetSubmission)
   end
 
   @doc """
@@ -137,33 +137,6 @@ defmodule Humaans.TimesheetSubmissions do
   @spec delete(client :: map(), id :: String.t()) :: delete_response()
   def delete(client, id) do
     Client.delete(client, "/timesheet-submissions/#{id}")
-    |> handle_response()
+    |> ResponseHandler.handle_delete_response()
   end
-
-  defp handle_response({:ok, %{status: status, body: %{"data" => data}}})
-       when status in 200..299 do
-    {_r, response} =
-      Enum.map_reduce(data, [], fn i, acc ->
-        {TimesheetSubmission.new(i), [TimesheetSubmission.new(i) | acc]}
-      end)
-
-    {:ok, response}
-  end
-
-  defp handle_response({:ok, %{status: status, body: %{"deleted" => deleted, "id" => id}}})
-       when status in 200..299 do
-    {:ok, %{deleted: deleted, id: id}}
-  end
-
-  defp handle_response({:ok, %{status: status, body: body}}) when status in 200..299 do
-    response = TimesheetSubmission.new(body)
-
-    {:ok, response}
-  end
-
-  defp handle_response({:ok, %{status: status, body: body}}) do
-    {:error, {status, body}}
-  end
-
-  defp handle_response({:error, _} = error), do: error
 end

--- a/test/humaans/response_handler_test.exs
+++ b/test/humaans/response_handler_test.exs
@@ -1,0 +1,116 @@
+defmodule Humaans.ResponseHandlerTest do
+  use ExUnit.Case, async: true
+
+  alias Humaans.ResponseHandler
+
+  # Mock resource module for testing
+  defmodule MockResource do
+    defstruct [:id, :name]
+
+    def new(data) do
+      %__MODULE__{
+        id: data["id"],
+        name: data["name"]
+      }
+    end
+  end
+
+  describe "handle_list_response/2" do
+    test "correctly handles successful list response" do
+      response = {:ok, %{status: 200, body: %{"data" => [%{"id" => "123", "name" => "Jane"}]}}}
+
+      assert {:ok, [%MockResource{id: "123", name: "Jane"}]} =
+               ResponseHandler.handle_list_response(response, MockResource)
+    end
+
+    test "correctly handles error response" do
+      response = {:ok, %{status: 422, body: %{"error" => "validation_failed"}}}
+
+      assert {:error, {422, %{"error" => "validation_failed"}}} =
+               ResponseHandler.handle_list_response(response, MockResource)
+    end
+
+    test "passes through connection errors" do
+      response = {:error, %{reason: :timeout}}
+
+      assert {:error, %{reason: :timeout}} =
+               ResponseHandler.handle_list_response(response, MockResource)
+    end
+  end
+
+  describe "handle_resource_response/2" do
+    test "correctly handles successful single resource response" do
+      response = {:ok, %{status: 200, body: %{"id" => "123", "name" => "Jane"}}}
+
+      assert {:ok, %MockResource{id: "123", name: "Jane"}} =
+               ResponseHandler.handle_resource_response(response, MockResource)
+    end
+
+    test "correctly handles error response" do
+      response = {:ok, %{status: 404, body: %{"error" => "not_found"}}}
+
+      assert {:error, {404, %{"error" => "not_found"}}} =
+               ResponseHandler.handle_resource_response(response, MockResource)
+    end
+
+    test "passes through connection errors" do
+      response = {:error, %{reason: :nxdomain}}
+
+      assert {:error, %{reason: :nxdomain}} =
+               ResponseHandler.handle_resource_response(response, MockResource)
+    end
+  end
+
+  describe "handle_delete_response/1" do
+    test "correctly handles successful delete response" do
+      response = {:ok, %{status: 200, body: %{"deleted" => true, "id" => "123"}}}
+
+      assert {:ok, %{deleted: true, id: "123"}} =
+               ResponseHandler.handle_delete_response(response)
+    end
+
+    test "correctly handles error response" do
+      response = {:ok, %{status: 403, body: %{"error" => "forbidden"}}}
+
+      assert {:error, {403, %{"error" => "forbidden"}}} =
+               ResponseHandler.handle_delete_response(response)
+    end
+
+    test "passes through connection errors" do
+      response = {:error, %{reason: :econnrefused}}
+
+      assert {:error, %{reason: :econnrefused}} =
+               ResponseHandler.handle_delete_response(response)
+    end
+  end
+
+  describe "handle_response/2" do
+    test "correctly handles list data response" do
+      response = {:ok, %{status: 200, body: %{"data" => [%{"id" => "123"}]}}}
+
+      assert {:ok, "processed"} =
+               ResponseHandler.handle_response(response, fn _ -> "processed" end)
+    end
+
+    test "correctly handles single item response" do
+      response = {:ok, %{status: 201, body: %{"id" => "123"}}}
+
+      assert {:ok, "processed"} =
+               ResponseHandler.handle_response(response, fn _ -> "processed" end)
+    end
+
+    test "correctly handles error response" do
+      response = {:ok, %{status: 500, body: %{"error" => "server_error"}}}
+
+      assert {:error, {500, %{"error" => "server_error"}}} =
+               ResponseHandler.handle_response(response, fn _ -> "processed" end)
+    end
+
+    test "passes through connection errors" do
+      response = {:error, "connection_error"}
+
+      assert {:error, "connection_error"} =
+               ResponseHandler.handle_response(response, fn _ -> "processed" end)
+    end
+  end
+end


### PR DESCRIPTION
💁 These changes introduce a new `Humaans.ResponseHandler` module with shared functionality for handling different API response types:
- `handle_list_response` for handling list responses
- `handle_resource_response` for handling single resource responses
- `handle_delete_response` for handling delete operation responses
- A generic `handle_response` function that powers the others

The existing resource modules are now refactored to use `ResponseHandler`.