### PR TITLE
Update package version in README to v0.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The package can be installed by adding `humaans` to your list of dependencies in
 ```elixir
 def deps do
   [
-    {:humaans, "~> 0.1.0"}
+    {:humaans, "~> 0.2.2"}
   ]
 end
 ```


### PR DESCRIPTION
💁 This change updates the package version in the README to the [currently available version, v0.2.2](https://github.com/sgerrand/ex_humaans/releases/tag/v0.2.2).