### PR TITLE
Bump package version to v0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The package can be installed by adding `humaans` to your list of dependencies in
 ```elixir
 def deps do
   [
-    {:humaans, "~> 0.2.2"}
+    {:humaans, "~> 0.3"}
   ]
 end
 ```


### PR DESCRIPTION
💁 This change bumps the minor version of this package in preparation for the next release. Dropping the patch version from the version stanza means that new users can pick up incremental changes.