### PR TITLE
CI: Improve automated release notes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,7 +55,7 @@ jobs:
       run: mix deps.get
 
     - name: Add changelog entry
-      run: echo "${{ inputs.changes }}" > RELEASE.md
+      run: echo -e "${{ inputs.changes }}" > RELEASE.md
 
     - name: Bump version, generate changelog, push to git, publish on hex.pm
       run: mix expublish.${{ inputs.version }} --branch=main --disable-test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ adheres to [Semantic Versioning](http://semver.org/).
 
 ## 0.3.0 - 2025-03-04
 
-### Changes\n- Introduce ResponseHandler to centrally manage how API responses are handled.
+### Changes
+
+- Introduce `ResponseHandler` to centrally manage how API responses are handled.
 
 
 ## 0.2.2 - 2025-03-04


### PR DESCRIPTION
💁 Not being able to use non-printing characters in release notes results in an ugly changelog. Carriage returns or line feeds are critical here. These changes enable them to be used as part of the Publish New Version workflow.