### PR TITLE
Fix bad request body encoding

### DIFF
--- a/lib/humaans/http_client/req.ex
+++ b/lib/humaans/http_client/req.ex
@@ -49,10 +49,13 @@ defmodule Humaans.HTTPClient.Req do
   """
   @impl true
   def request(client, opts) do
+    method = Keyword.get(opts, :method)
+
     opts =
       Enum.reduce(opts, [], fn opt, acc ->
         case opt do
-          {:body, body} -> [{:json, body} | acc]
+          {:body, body} when method in [:patch, :post, :put] -> [{:json, body} | acc]
+          {:body, body} -> [{:body, body} | acc]
           {key, val} -> [{key, val} | acc]
         end
       end)

--- a/lib/humaans/http_client/req.ex
+++ b/lib/humaans/http_client/req.ex
@@ -49,16 +49,22 @@ defmodule Humaans.HTTPClient.Req do
   """
   @impl true
   def request(client, opts) do
-    method = Keyword.get(opts, :method)
-
     opts =
-      Enum.reduce(opts, [], fn opt, acc ->
-        case opt do
-          {:body, body} when method in [:patch, :post, :put] -> [{:json, body} | acc]
-          {:body, body} -> [{:body, body} | acc]
-          {key, val} -> [{key, val} | acc]
-        end
-      end)
+      case Keyword.get(opts, :method) do
+        method when method in [:patch, :post, :put] ->
+          case Keyword.get(opts, :body) do
+            nil ->
+              opts
+
+            body ->
+              opts
+              |> Keyword.delete(:body)
+              |> Keyword.put(:json, body)
+          end
+
+        _ ->
+          opts
+      end
 
     Req.new(
       base_url: client.base_url,

--- a/lib/humaans/http_client/req.ex
+++ b/lib/humaans/http_client/req.ex
@@ -49,6 +49,14 @@ defmodule Humaans.HTTPClient.Req do
   """
   @impl true
   def request(client, opts) do
+    opts =
+      Enum.reduce(opts, [], fn opt, acc ->
+        case opt do
+          {:body, body} -> [{:json, body} | acc]
+          {key, val} -> [{key, val} | acc]
+        end
+      end)
+
     Req.new(
       base_url: client.base_url,
       auth: {:bearer, client.access_token}

--- a/test/humaans/http_client/req_test.exs
+++ b/test/humaans/http_client/req_test.exs
@@ -1,11 +1,13 @@
 defmodule Humaans.HTTPClient.ReqTest do
   use ExUnit.Case, async: true
 
+  alias Humaans.HTTPClient.Req, as: HumaansReq
+
   setup do
     client = %Humaans{
       access_token: "test-token",
       base_url: "https://app.humaans.io/api",
-      http_client: Humaans.HTTPClient.Req
+      http_client: HumaansReq
     }
 
     [client: client]
@@ -18,7 +20,7 @@ defmodule Humaans.HTTPClient.ReqTest do
 
       request_opts = Keyword.put(request_opts, :base_url, client.base_url)
 
-      result = Humaans.HTTPClient.Req.request(client, request_opts)
+      result = HumaansReq.request(client, request_opts)
 
       assert result == {:ok, response}
     end
@@ -29,7 +31,7 @@ defmodule Humaans.HTTPClient.ReqTest do
       {response, request_opts} =
         setup_test(:get, "/people", response_body, 200, params: [limit: 10, offset: 0])
 
-      result = Humaans.HTTPClient.Req.request(client, request_opts)
+      result = HumaansReq.request(client, request_opts)
 
       assert result == {:ok, response}
     end
@@ -39,7 +41,7 @@ defmodule Humaans.HTTPClient.ReqTest do
       body = %{name: "Test User", email: "test@example.com"}
       {response, request_opts} = setup_test(:post, "/people", response_body, 201, body: body)
 
-      result = Humaans.HTTPClient.Req.request(client, request_opts)
+      result = HumaansReq.request(client, request_opts)
 
       assert result == {:ok, response}
     end
@@ -49,7 +51,7 @@ defmodule Humaans.HTTPClient.ReqTest do
       body = %{name: "Updated User"}
       {response, request_opts} = setup_test(:patch, "/people/123", response_body, 200, body: body)
 
-      result = Humaans.HTTPClient.Req.request(client, request_opts)
+      result = HumaansReq.request(client, request_opts)
 
       assert result == {:ok, response}
     end
@@ -58,7 +60,7 @@ defmodule Humaans.HTTPClient.ReqTest do
       response_body = %{"id" => "123", "deleted" => true}
       {response, request_opts} = setup_test(:delete, "/people/123", response_body)
 
-      result = Humaans.HTTPClient.Req.request(client, request_opts)
+      result = HumaansReq.request(client, request_opts)
 
       assert result == {:ok, response}
     end
@@ -77,7 +79,7 @@ defmodule Humaans.HTTPClient.ReqTest do
         adapter: adapter
       ]
 
-      result = Humaans.HTTPClient.Req.request(client, request_opts)
+      result = HumaansReq.request(client, request_opts)
 
       assert result == {:error, error_response}
     end


### PR DESCRIPTION
💁 HTTP requests with a body are currently encoded incorrectly by `Humaans.HTTPClient.Req`, which results in failure responses like the following:
```
> Humaans.People.update(c, "some-access-token", %{preferred_name: "El Sasho"})
** (ArgumentError) errors were found at the given arguments:

  * 1st argument: not an iodata term

    :erlang.iolist_size({:preferred_name, "El Sasho"})
    (mint 1.7.1) lib/mint/http1.ex:431: Mint.HTTP1.validate_chunk/2
    (mint 1.7.1) lib/mint/http1.ex:388: Mint.HTTP1.stream_request_body/3
    (finch 0.19.0) lib/finch/http1/conn.ex:185: anonymous fn/3 in Finch.HTTP1.Conn.stream_request_body/3
    (elixir 1.18.2) lib/enum.ex:4964: Enumerable.List.reduce/3
    (elixir 1.18.2) lib/enum.ex:2600: Enum.reduce_while/3
    (finch 0.19.0) lib/finch/http1/conn.ex:176: Finch.HTTP1.Conn.maybe_stream_request_body/3
    iex:4: (file)
```
This change ensures that all HTTP requests with a body are encoded as JSON and resolves this issue. Taking this low-level approach to ensuring the encoding is correctly configured prevents further, larger changes to the interfaces or arity of other functions, e.g. `Humaans.Client.request/4`.