### PR TITLE
CI: workflow and job improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   required:
     name: Required
-    needs: [dependencies, docs, formatting, test]
+    needs: [dependencies, docs, test]
     runs-on: ubuntu-latest
 
     steps:
@@ -78,36 +78,6 @@ jobs:
     - name: Generate documentation
       run: mix docs --warnings-as-errors
 
-  formatting:
-    name: Formatting
-    runs-on: ubuntu-latest
-
-    env:
-      MIX_ENV: test
-
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Elixir
-      id: setup-beam
-      uses: erlef/setup-beam@v1
-      with:
-        version-file: '.tool-versions'
-        version-type: 'strict'
-    - name: Cache dependencies
-      id: cache-deps
-      uses: actions/cache@v4
-      with:
-        path: |
-          _build
-          deps
-        key: ${{ runner.os }}-${{ steps.setup-beam.outputs.otp-version }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ hashFiles('**/mix.lock') }}
-        restore-keys: ${{ runner.os }}-${{ steps.setup-beam.outputs.otp-version }}-${{ steps.setup-beam.outputs.elixir-version }}-
-    - name: Install and compile dependencies
-      if: steps.cache-deps.outputs.cache-hit != 'true'
-      run: mix do deps.get --only ${{ env.MIX_ENV }}, deps.compile
-    - name: Check code format
-      run: mix format --check-formatted
-
   test:
     name: Tests (Elixir ${{ matrix.elixir }} / OTP ${{ matrix.otp }})
     runs-on: ubuntu-latest
@@ -125,6 +95,10 @@ jobs:
             otp: '24'
           - elixir: '1.18'
             otp: '24'
+        include:
+          - elixir: '1.18'
+            otp: '27'
+            lint: true
 
     env:
       MIX_ENV: test
@@ -148,6 +122,9 @@ jobs:
     - name: Install and compile dependencies
       if: steps.cache-deps.outputs.cache-hit != 'true'
       run: mix do deps.get --only ${{ env.MIX_ENV }}, deps.compile
+    - name: Check that files are formatted
+      run: mix format --check-formatted
+      if: ${{ matrix.lint }}
     - name: Compile code
       run: mix compile
     - name: Run tests


### PR DESCRIPTION
💁 These changes improve the GitHub Actions workflows and jobs within continuous integration:
- Run code formatting check inside the test job instead of as a standalone job.
- Raise warnings as errors when compiling code.
- Install and run `Credo` inside the test job for static code analysis.
- Ensure that `mix.lock` is up-to-date when pulling dependencies.
- Let `Expublish` run the tests inside the publish workflow instead of calling out to the CI workflow.