### PR TITLE
Enable actions/checkout to clone repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,8 @@ on:
     branches:
       - main
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   required:


### PR DESCRIPTION
💁 For `actions/checkout` to be able to clone this repository, the `GITHUB_TOKEN` needs permission to read the contents.