### PR TITLE
Disable credo check for Person API response struct

### DIFF
--- a/lib/humaans/resources/person.ex
+++ b/lib/humaans/resources/person.ex
@@ -3,6 +3,7 @@ defmodule Humaans.Resources.Person do
   Representation of a Person resource.
   """
 
+  # credo:disable-for-next-line Credo.Check.Warning.StructFieldAmount
   defstruct [
     :id,
     :company_id,


### PR DESCRIPTION
💁 While `credo` has raised a informative general warning about the size of structs, the shape and size of the Humaans' API response is out of the control of this API client. These changes configure `credo` to ignore this warning and avoid unnecessarily redesigning the struct for this API resource.
```
$ mix credo explain lib/humaans/resources/person.ex:6:3

  Humaans.Resources.Person
┃
┃   [W] Category: warning
┃    →  Priority: normal
┃
┃       Struct has more than 31 fields (66 found).
┃       lib/humaans/resources/person.ex:6:3 (Humaans.Resources.Person)
┃
┃    __ CODE IN QUESTION
┃
┃     5
┃     6   defstruct [
┃         ^^^^^^^^^
┃     7     :id,
┃     8     :company_id,
┃
┃    __ WHY IT MATTERS
┃
┃       Avoid structs with 32 or more fields.
┃
┃       Structs in Elixir are implemented as compile-time maps, which have a
┃       predefined amount of fields.
┃
┃       When structs have 32 or more fields, their internal representation in
┃       the Erlang Virtual Machines changes, potentially leading to bloating
┃       and higher memory usage.
┃
┃       https://hexdocs.pm/elixir/1.19.0/code-anti-patterns.html#structs-with-32-fields-or-more
┃
┃    __ CONFIGURATION OPTIONS
┃
┃       To configure this check, use this tuple
┃
┃         {Credo.Check.Warning.StructFieldAmount, <params>}
┃
┃       with <params> being false or any combination of these keywords:
┃
┃         max_fields:  The maximum number of field a struct should be allowed to have.
┃                      (defaults to 31)
```