### PR TITLE
Add pre-commit hooks with lefthook

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,10 @@
+{
+  // Exclude generated/vendored directories and files managed by tooling
+  "ignores": ["CHANGELOG.md", ".claude/", "_build/", "deps/"],
+  "config": {
+    // Badge URLs and long code examples exceed 80 chars
+    "MD013": false,
+    // CHANGELOG repeats section names (## Added, ## Fixed) across versions
+    "MD024": false
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,58 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Development
+
+### Requirements
+
+- Elixir ~> 1.15
+- Homebrew (for development tools: `actionlint`, `check-jsonschema`, `lefthook`, `markdownlint-cli2`)
+
+### Setup
+
+```shell
+bin/setup   # installs dev tools via Homebrew and configures git hooks (lefthook)
+mix setup   # installs Elixir dependencies
+```
+
+### Commands
+
+- Run all tests: `mix test`
+- Run single test: `mix test path/to/test_file.exs:line_number`
+- Lint: `mix credo`
+- Format: `mix format`
+
+## Architecture
+
+`ex_humaans` is an Elixir HTTP client library for the [Humaans](https://humaans.io) HR API.
+
+### Request flow
+
+```text
+Humaans.new/1
+  → resource module (People, Companies, etc.)
+    → Humaans.Client (builds URL + headers)
+      → Humaans.HTTPClient.Behaviour impl (default: Humaans.HTTPClient.Req)
+        → Req library
+          → Humaans.ResponseHandler (parses response, returns struct or error)
+```
+
+### Key patterns
+
+**Client creation** — `Humaans.new(access_token: "...", http_client: MyClient)`. The `:http_client` field allows injecting a custom implementation of `Humaans.HTTPClient.Behaviour` (used in tests via `Humaans.MockHTTPClient`).
+
+**Resource modules** — Each resource (`People`, `Companies`, `BankAccounts`, `Compensations`, `CompensationTypes`, `TimesheetEntries`, `TimesheetSubmissions`) exposes whichever of `list/2`, `create/2`, `retrieve/2`, `update/3`, `delete/2` the API supports. All return `{:ok, struct}` or `{:error, reason}`.
+
+**Resource structs** — Live in `lib/humaans/resources/`. Use `ExConstructor` for automatic camelCase→snake_case JSON mapping. `Humaans.Response` holds raw HTTP responses (`status`, `headers`, `body`).
+
+**Response handling** — `Humaans.ResponseHandler` unwraps `{"data": [...]}` envelopes and converts payloads to typed structs.
+
+### Testing
+
+Tests mock the HTTP layer via `Mox`. Setup creates a client with `Humaans.MockHTTPClient`, sets expectations with `Mox.expect/3` to assert on request shape and return fixture data, then asserts on the returned structs.
+
+## Git Flow
+
+- Branch naming: `feature-description-ticket-id`
+- PRs should include tests and documentation updates

--- a/README.md
+++ b/README.md
@@ -60,6 +60,32 @@ client = Humaans.new(access_token: "YOUR_ACCESS_TOKEN")
 - `Humaans.TimesheetEntries` - Work with timesheet entry resources
 - `Humaans.TimesheetSubmissions` - Work with timesheet submission resources
 
+## Development
+
+### Requirements
+
+- Elixir ~> 1.15
+- [Homebrew](https://brew.sh) (for installing development tools)
+
+### Setup
+
+Run the setup script to install development tools and git hooks:
+
+```shell
+bin/setup
+```
+
+This installs `actionlint`, `check-jsonschema`, `lefthook`, and `markdownlint-cli2` via Homebrew, then configures the pre-commit hooks.
+
+### Commands
+
+| Command | Description |
+| --- | --- |
+| `mix setup` | Install dependencies |
+| `mix test` | Run the test suite |
+| `mix credo` | Run the linter |
+| `mix format` | Format source files |
+
 ## License
 
 Humaans is [released under the MIT license](LICENSE).

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+brew install actionlint check-jsonschema lefthook markdownlint-cli2
+lefthook install

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,24 @@
+pre-commit:
+  parallel: true
+  commands:
+    mix-format:
+      glob: "*.{ex,exs}"
+      run: mix format --check-formatted
+    actionlint:
+      glob: ".github/workflows/*.yml"
+      run: actionlint {staged_files}
+    check-github-workflows:
+      glob: ".github/workflows/*.yml"
+      run: check-jsonschema --builtin-schema vendor.github-workflows {staged_files}
+    check-dependabot:
+      glob: ".github/dependabot.{yml,yaml}"
+      run: check-jsonschema --builtin-schema vendor.dependabot {staged_files}
+    check-release-please-config:
+      glob: "release-please-config.json"
+      run: check-jsonschema --schemafile https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json {staged_files}
+    check-release-please-manifest:
+      glob: ".release-please-manifest.json"
+      run: check-jsonschema --schemafile https://raw.githubusercontent.com/googleapis/release-please/main/schemas/manifest.json {staged_files}
+    markdownlint:
+      glob: "*.md"
+      run: markdownlint-cli2 {staged_files}


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Add [lefthook](https://github.com/evilmartians/lefthook) for git pre-commit hooks, enforcing format, lint, and schema checks on staged files
- Add `bin/setup` script to install required dev tools via Homebrew and configure hooks
- Add `markdownlint-cli2` config, excluding generated/vendored directories
- Add `Humaans.Response` struct module
- Document the development setup in `README.md` and `CLAUDE.md`

## Test plan

- [x] Run `bin/setup` on a fresh checkout and confirm tools install and hooks are configured
- [x] Stage a malformatted `.ex` file and confirm the `mix-format` hook rejects it
- [x] Stage a `.md` file with lint errors and confirm `markdownlint` hook rejects it
- [x] Run `mix test` to confirm existing tests still pass