### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,9 @@ jobs:
         restore-keys: ${{ runner.os }}-${{ env.MIX_ENV }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-
     - name: Install and compile dependencies
       if: steps.cache-deps.outputs.cache-hit != 'true'
-      run: mix do deps.get --only ${{ env.MIX_ENV }}, deps.compile
+      run: |
+        # shellcheck disable=SC1010
+        mix do deps.get --only ${{ env.MIX_ENV }}, deps.compile
     - name: Generate documentation
       run: mix docs --warnings-as-errors
 
@@ -93,7 +95,9 @@ jobs:
         restore-keys: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-
     - name: Install and compile dependencies
       if: steps.cache-deps.outputs.cache-hit != 'true'
-      run: mix do deps.get --only ${{ env.MIX_ENV }}, deps.compile
+      run: |
+        # shellcheck disable=SC1010
+        mix do deps.get --only ${{ env.MIX_ENV }}, deps.compile
     - name: Check that mix.lock is up to date
       run: mix deps.get --check-locked
       if: ${{ matrix.lint }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
     - name: Set up Elixir
       id: setup-beam
       uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
@@ -79,6 +81,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
     - name: Set up Elixir
       uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,16 +27,16 @@ jobs:
       MIX_ENV: dev
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Set up Elixir
       id: setup-beam
-      uses: erlef/setup-beam@v1
+      uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
       with:
         version-file: '.tool-versions'
         version-type: 'strict'
     - name: Cache dependencies
       id: cache-deps
-      uses: actions/cache@v5
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: |
           _build
@@ -78,15 +78,15 @@ jobs:
       MIX_ENV: test
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Set up Elixir
-      uses: erlef/setup-beam@v1
+      uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
       with:
         elixir-version: ${{matrix.elixir}}
         otp-version: ${{matrix.otp}}
     - name: Cache dependencies
       id: cache-deps
-      uses: actions/cache@v5
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: |
           _build

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -15,9 +15,9 @@ jobs:
     name: "Report Mix Dependencies"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: erlef/mix-dependency-submission@v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: erlef/mix-dependency-submission@c4a36104ac7614b1b66d0da6e8a1c7d6d07bc52b # v1.3.2
         with:
           install-deps: true
-      - uses: actions/dependency-review-action@v4
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         if: "${{ github.event_name == 'pull_request' }}"

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: erlef/mix-dependency-submission@c4a36104ac7614b1b66d0da6e8a1c7d6d07bc52b # v1.3.2
         with:
           install-deps: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,7 +54,9 @@ jobs:
       run: mix deps.get
 
     - name: Add changelog entry
-      run: echo -e "${{ inputs.changes }}" > RELEASE.md
+      run: echo -e "${INPUTS_CHANGES}" > RELEASE.md
+      env:
+        INPUTS_CHANGES: ${{ inputs.changes }}
 
     - name: Bump version, generate changelog, push to git, publish on hex.pm
       run: mix expublish.${{ inputs.version }} --branch=main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,7 @@ jobs:
         token: ${{ secrets.GH_PUBLISH_PAT }}
         fetch-depth: 0
         ref: main
+        persist-credentials: false
 
     - name: Config git client
       run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
       HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         token: ${{ secrets.GH_PUBLISH_PAT }}
         fetch-depth: 0
@@ -37,13 +37,13 @@ jobs:
 
     - name: Setup Elixir
       id: setup-beam
-      uses: erlef/setup-beam@v1
+      uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
       with:
         version-file: '.tool-versions'
         version-type: 'strict'
 
     - name: Restore dependencies cache
-      uses: actions/cache@v5
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: deps
         key: ${{ runner.os }}-publish-mix-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-${{ hashFiles('**/mix.lock') }}


### PR DESCRIPTION
💁 These changes update the existing GitHub Actions workflows to:
- pin actions to specific commit hashes
- avoid persisting git tokens after cloning code
- prevent inputs being expanded