### PR TITLE
refactor: remove unenforced @callback declarations from resource modules

### DIFF
--- a/lib/humaans/bank_accounts.ex
+++ b/lib/humaans/bank_accounts.ex
@@ -10,12 +10,6 @@ defmodule Humaans.BankAccounts do
   @type list_response :: {:ok, [%BankAccount{}]} | {:error, any()}
   @type response :: {:ok, %BankAccount{}} | {:error, any()}
 
-  @callback list(client :: map(), map()) :: {:ok, map()} | {:error, any()}
-  @callback create(client :: map(), map()) :: {:ok, map()} | {:error, any()}
-  @callback retrieve(client :: map(), String.t()) :: {:ok, map()} | {:error, any()}
-  @callback update(client :: map(), String.t(), map()) :: {:ok, map()} | {:error, any()}
-  @callback delete(client :: map(), String.t()) :: {:ok, map()} | {:error, any()}
-
   @doc """
   Lists all bank account resources.
 

--- a/lib/humaans/companies.ex
+++ b/lib/humaans/companies.ex
@@ -10,10 +10,6 @@ defmodule Humaans.Companies do
   @type list_response :: {:ok, [%Company{}]} | {:error, any()}
   @type response :: {:ok, %Company{}} | {:error, any()}
 
-  @callback list(client :: map(), map()) :: {:ok, map()} | {:error, any()}
-  @callback get(client :: map(), String.t()) :: {:ok, map()} | {:error, any()}
-  @callback update(client :: map(), String.t(), map()) :: {:ok, map()} | {:error, any()}
-
   @doc """
   Lists all company resources.
 

--- a/lib/humaans/compensation_types.ex
+++ b/lib/humaans/compensation_types.ex
@@ -11,12 +11,6 @@ defmodule Humaans.CompensationTypes do
   @type list_response :: {:ok, [%CompensationType{}]} | {:error, any()}
   @type response :: {:ok, %CompensationType{}} | {:error, any()}
 
-  @callback list(client :: map(), map()) :: {:ok, map()} | {:error, any()}
-  @callback create(client :: map(), map()) :: {:ok, map()} | {:error, any()}
-  @callback retrieve(client :: map(), String.t()) :: {:ok, map()} | {:error, any()}
-  @callback update(client :: map(), String.t(), map()) :: {:ok, map()} | {:error, any()}
-  @callback delete(client :: map(), String.t()) :: {:ok, map()} | {:error, any()}
-
   @doc """
   Lists all compensation type resources.
 

--- a/lib/humaans/compensations.ex
+++ b/lib/humaans/compensations.ex
@@ -12,12 +12,6 @@ defmodule Humaans.Compensations do
   @type list_response :: {:ok, [%Compensation{}]} | {:error, any()}
   @type response :: {:ok, %Compensation{}} | {:error, any()}
 
-  @callback list(client :: map(), map()) :: {:ok, map()} | {:error, any()}
-  @callback create(client :: map(), map()) :: {:ok, map()} | {:error, any()}
-  @callback retrieve(client :: map(), String.t()) :: {:ok, map()} | {:error, any()}
-  @callback update(client :: map(), String.t(), map()) :: {:ok, map()} | {:error, any()}
-  @callback delete(client :: map(), String.t()) :: {:ok, map()} | {:error, any()}
-
   @doc """
   Lists all compensation resources.
 

--- a/lib/humaans/people.ex
+++ b/lib/humaans/people.ex
@@ -10,12 +10,6 @@ defmodule Humaans.People do
   @type list_response :: {:ok, [%Person{}]} | {:error, any()}
   @type response :: {:ok, %Person{}} | {:error, any()}
 
-  @callback list(client :: map(), map()) :: {:ok, map()} | {:error, any()}
-  @callback create(client :: map(), map()) :: {:ok, map()} | {:error, any()}
-  @callback retrieve(client :: map(), String.t()) :: {:ok, map()} | {:error, any()}
-  @callback update(client :: map(), String.t(), map()) :: {:ok, map()} | {:error, any()}
-  @callback delete(client :: map(), String.t()) :: {:ok, map()} | {:error, any()}
-
   @doc """
   Lists all people resources.
 

--- a/lib/humaans/timesheet_entries.ex
+++ b/lib/humaans/timesheet_entries.ex
@@ -11,12 +11,6 @@ defmodule Humaans.TimesheetEntries do
   @type list_response :: {:ok, [%TimesheetEntry{}]} | {:error, any()}
   @type response :: {:ok, %TimesheetEntry{}} | {:error, any()}
 
-  @callback list(client :: map(), map()) :: {:ok, map()} | {:error, any()}
-  @callback create(client :: map(), map()) :: {:ok, map()} | {:error, any()}
-  @callback retrieve(client :: map(), String.t()) :: {:ok, map()} | {:error, any()}
-  @callback update(client :: map(), String.t(), map()) :: {:ok, map()} | {:error, any()}
-  @callback delete(client :: map(), String.t()) :: {:ok, map()} | {:error, any()}
-
   @doc """
   Lists all timesheet entry resources.
 

--- a/lib/humaans/timesheet_submissions.ex
+++ b/lib/humaans/timesheet_submissions.ex
@@ -12,12 +12,6 @@ defmodule Humaans.TimesheetSubmissions do
   @type list_response :: {:ok, [%TimesheetSubmission{}]} | {:error, any()}
   @type response :: {:ok, %TimesheetSubmission{}} | {:error, any()}
 
-  @callback list(client :: map(), map()) :: {:ok, map()} | {:error, any()}
-  @callback create(client :: map(), map()) :: {:ok, map()} | {:error, any()}
-  @callback retrieve(client :: map(), String.t()) :: {:ok, map()} | {:error, any()}
-  @callback update(client :: map(), String.t(), map()) :: {:ok, map()} | {:error, any()}
-  @callback delete(client :: map(), String.t()) :: {:ok, map()} | {:error, any()}
-
   @doc """
   Lists all timesheet submission resources.
 


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Remove `@callback` declarations from all resource modules (`People`, `Companies`, `BankAccounts`, `Compensations`, `CompensationTypes`, `TimesheetEntries`, `TimesheetSubmissions`)

These declarations were unenforced — none of the modules declared `@behaviour`, so the compiler never validated them against any contract. The same information is already expressed through `@spec` and `@doc` annotations on each function.