### PR TITLE
chore(build): ignore local coding agent configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ humaans-*.tar
 
 # Ignore Expublish artefacts
 RELEASE.md
+
+# Where coding agents store their local config.
+/.claude/
+/.codex/


### PR DESCRIPTION
💁 These changes add git ignores for where popular coding agents store their local configuration files.