### PR TITLE
feat: introduce Humaans.Error for structured error handling

### DIFF
--- a/lib/humaans/bank_accounts.ex
+++ b/lib/humaans/bank_accounts.ex
@@ -6,9 +6,9 @@ defmodule Humaans.BankAccounts do
 
   alias Humaans.{Client, Resources.BankAccount, ResponseHandler}
 
-  @type delete_response :: {:ok, %{id: String.t(), deleted: bool()}} | {:error, any()}
-  @type list_response :: {:ok, [%BankAccount{}]} | {:error, any()}
-  @type response :: {:ok, %BankAccount{}} | {:error, any()}
+  @type delete_response :: {:ok, %{id: String.t(), deleted: bool()}} | {:error, Humaans.Error.t()}
+  @type list_response :: {:ok, [%BankAccount{}]} | {:error, Humaans.Error.t()}
+  @type response :: {:ok, %BankAccount{}} | {:error, Humaans.Error.t()}
 
   @doc """
   Lists all bank account resources.

--- a/lib/humaans/companies.ex
+++ b/lib/humaans/companies.ex
@@ -7,8 +7,8 @@ defmodule Humaans.Companies do
 
   alias Humaans.{Client, Resources.Company, ResponseHandler}
 
-  @type list_response :: {:ok, [%Company{}]} | {:error, any()}
-  @type response :: {:ok, %Company{}} | {:error, any()}
+  @type list_response :: {:ok, [%Company{}]} | {:error, Humaans.Error.t()}
+  @type response :: {:ok, %Company{}} | {:error, Humaans.Error.t()}
 
   @doc """
   Lists all company resources.

--- a/lib/humaans/compensation_types.ex
+++ b/lib/humaans/compensation_types.ex
@@ -7,9 +7,9 @@ defmodule Humaans.CompensationTypes do
 
   alias Humaans.{Client, Resources.CompensationType, ResponseHandler}
 
-  @type delete_response :: {:ok, %{id: String.t(), deleted: bool()}} | {:error, any()}
-  @type list_response :: {:ok, [%CompensationType{}]} | {:error, any()}
-  @type response :: {:ok, %CompensationType{}} | {:error, any()}
+  @type delete_response :: {:ok, %{id: String.t(), deleted: bool()}} | {:error, Humaans.Error.t()}
+  @type list_response :: {:ok, [%CompensationType{}]} | {:error, Humaans.Error.t()}
+  @type response :: {:ok, %CompensationType{}} | {:error, Humaans.Error.t()}
 
   @doc """
   Lists all compensation type resources.

--- a/lib/humaans/compensations.ex
+++ b/lib/humaans/compensations.ex
@@ -8,9 +8,9 @@ defmodule Humaans.Compensations do
 
   alias Humaans.{Client, Resources.Compensation, ResponseHandler}
 
-  @type delete_response :: {:ok, %{id: String.t(), deleted: bool()}} | {:error, any()}
-  @type list_response :: {:ok, [%Compensation{}]} | {:error, any()}
-  @type response :: {:ok, %Compensation{}} | {:error, any()}
+  @type delete_response :: {:ok, %{id: String.t(), deleted: bool()}} | {:error, Humaans.Error.t()}
+  @type list_response :: {:ok, [%Compensation{}]} | {:error, Humaans.Error.t()}
+  @type response :: {:ok, %Compensation{}} | {:error, Humaans.Error.t()}
 
   @doc """
   Lists all compensation resources.

--- a/lib/humaans/error.ex
+++ b/lib/humaans/error.ex
@@ -1,0 +1,51 @@
+defmodule Humaans.Error do
+  @moduledoc """
+  Represents an error returned by the Humaans API or HTTP layer.
+
+  ## Error types
+
+  * `:api_error` - The API returned a non-2xx HTTP status code. The `status`
+    field contains the HTTP status code and `body` contains the parsed response
+    body.
+  * `:network_error` - A transport-level error occurred before a response was
+    received (e.g. connection refused, DNS failure). The `reason` field contains
+    the underlying error.
+
+  ## Examples
+
+      case Humaans.People.retrieve(client, "missing-id") do
+        {:ok, person} ->
+          person
+
+        {:error, %Humaans.Error{type: :api_error, status: 404}} ->
+          :not_found
+
+        {:error, %Humaans.Error{type: :api_error, status: 401}} ->
+          :unauthorized
+
+        {:error, %Humaans.Error{type: :network_error, reason: reason}} ->
+          {:network_failure, reason}
+      end
+
+  """
+
+  @type error_type :: :api_error | :network_error
+
+  @type t :: %__MODULE__{
+          type: error_type(),
+          status: non_neg_integer() | nil,
+          body: map() | nil,
+          reason: any()
+        }
+
+  defexception [:type, :status, :body, :reason]
+
+  @impl Exception
+  def message(%__MODULE__{type: :api_error, status: status, body: body}) do
+    "Humaans API error: HTTP #{status} - #{inspect(body)}"
+  end
+
+  def message(%__MODULE__{type: :network_error, reason: reason}) do
+    "Humaans network error: #{inspect(reason)}"
+  end
+end

--- a/lib/humaans/people.ex
+++ b/lib/humaans/people.ex
@@ -6,9 +6,9 @@ defmodule Humaans.People do
 
   alias Humaans.{Client, Resources.Person, ResponseHandler}
 
-  @type delete_response :: {:ok, %{id: String.t(), deleted: bool()}} | {:error, any()}
-  @type list_response :: {:ok, [%Person{}]} | {:error, any()}
-  @type response :: {:ok, %Person{}} | {:error, any()}
+  @type delete_response :: {:ok, %{id: String.t(), deleted: bool()}} | {:error, Humaans.Error.t()}
+  @type list_response :: {:ok, [%Person{}]} | {:error, Humaans.Error.t()}
+  @type response :: {:ok, %Person{}} | {:error, Humaans.Error.t()}
 
   @doc """
   Lists all people resources.

--- a/lib/humaans/response_handler.ex
+++ b/lib/humaans/response_handler.ex
@@ -19,7 +19,7 @@ defmodule Humaans.ResponseHandler do
 
   """
   @spec handle_list_response({:ok, map()} | {:error, any()}, module()) ::
-          {:ok, [struct()]} | {:error, any()}
+          {:ok, [struct()]} | {:error, Humaans.Error.t()}
   def handle_list_response(response, resource_module) do
     handle_response(response, fn data ->
       {_r, resources} =
@@ -47,7 +47,7 @@ defmodule Humaans.ResponseHandler do
 
   """
   @spec handle_resource_response({:ok, map()} | {:error, any()}, module()) ::
-          {:ok, struct()} | {:error, any()}
+          {:ok, struct()} | {:error, Humaans.Error.t()}
   def handle_resource_response(response, resource_module) do
     handle_response(response, fn body ->
       resource_module.new(body)
@@ -68,7 +68,7 @@ defmodule Humaans.ResponseHandler do
 
   """
   @spec handle_delete_response({:ok, map()} | {:error, any()}) ::
-          {:ok, %{deleted: boolean(), id: String.t()}} | {:error, any()}
+          {:ok, %{deleted: boolean(), id: String.t()}} | {:error, Humaans.Error.t()}
   def handle_delete_response(response) do
     case response do
       {:ok, %{status: status, body: %{"deleted" => deleted, "id" => id}}}
@@ -90,7 +90,7 @@ defmodule Humaans.ResponseHandler do
 
   """
   @spec handle_response({:ok, map()} | {:error, any()}, (any() -> any())) ::
-          {:ok, any()} | {:error, any()}
+          {:ok, any()} | {:error, Humaans.Error.t()}
   def handle_response(response, success_handler) do
     case response do
       {:ok, %{status: status, body: %{"data" => data}}} when status in 200..299 ->
@@ -100,10 +100,10 @@ defmodule Humaans.ResponseHandler do
         {:ok, success_handler.(body)}
 
       {:ok, %{status: status, body: body}} ->
-        {:error, {status, body}}
+        {:error, %Humaans.Error{type: :api_error, status: status, body: body}}
 
-      {:error, _} = error ->
-        error
+      {:error, reason} ->
+        {:error, %Humaans.Error{type: :network_error, reason: reason}}
     end
   end
 end

--- a/lib/humaans/timesheet_entries.ex
+++ b/lib/humaans/timesheet_entries.ex
@@ -7,9 +7,9 @@ defmodule Humaans.TimesheetEntries do
 
   alias Humaans.{Client, Resources.TimesheetEntry, ResponseHandler}
 
-  @type delete_response :: {:ok, %{id: String.t(), deleted: bool()}} | {:error, any()}
-  @type list_response :: {:ok, [%TimesheetEntry{}]} | {:error, any()}
-  @type response :: {:ok, %TimesheetEntry{}} | {:error, any()}
+  @type delete_response :: {:ok, %{id: String.t(), deleted: bool()}} | {:error, Humaans.Error.t()}
+  @type list_response :: {:ok, [%TimesheetEntry{}]} | {:error, Humaans.Error.t()}
+  @type response :: {:ok, %TimesheetEntry{}} | {:error, Humaans.Error.t()}
 
   @doc """
   Lists all timesheet entry resources.

--- a/lib/humaans/timesheet_submissions.ex
+++ b/lib/humaans/timesheet_submissions.ex
@@ -8,9 +8,9 @@ defmodule Humaans.TimesheetSubmissions do
 
   alias Humaans.{Client, Resources.TimesheetSubmission, ResponseHandler}
 
-  @type delete_response :: {:ok, %{id: String.t(), deleted: bool()}} | {:error, any()}
-  @type list_response :: {:ok, [%TimesheetSubmission{}]} | {:error, any()}
-  @type response :: {:ok, %TimesheetSubmission{}} | {:error, any()}
+  @type delete_response :: {:ok, %{id: String.t(), deleted: bool()}} | {:error, Humaans.Error.t()}
+  @type list_response :: {:ok, [%TimesheetSubmission{}]} | {:error, Humaans.Error.t()}
+  @type response :: {:ok, %TimesheetSubmission{}} | {:error, Humaans.Error.t()}
 
   @doc """
   Lists all timesheet submission resources.

--- a/test/humaans/bank_accounts_test.exs
+++ b/test/humaans/bank_accounts_test.exs
@@ -65,7 +65,7 @@ defmodule Humaans.BankAccountsTest do
         {:ok, %{status: 404, body: %{"error" => "Bank Account not found"}}}
       end)
 
-      assert {:error, {404, %{"error" => "Bank Account not found"}}} ==
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
                Humaans.BankAccounts.list(client)
     end
 
@@ -75,7 +75,8 @@ defmodule Humaans.BankAccountsTest do
         {:error, "something unexpected happened"}
       end)
 
-      assert {:error, "something unexpected happened"} ==
+      assert {:error,
+              %Humaans.Error{type: :network_error, reason: "something unexpected happened"}} =
                Humaans.BankAccounts.list(client)
     end
   end

--- a/test/humaans/companies_test.exs
+++ b/test/humaans/companies_test.exs
@@ -65,7 +65,7 @@ defmodule Humaans.CompaniesTest do
         {:ok, %{status: 404, body: %{"error" => "Company not found"}}}
       end)
 
-      assert {:error, {404, %{"error" => "Company not found"}}} ==
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
                Humaans.Companies.list(client)
     end
 
@@ -75,7 +75,8 @@ defmodule Humaans.CompaniesTest do
         {:error, "something unexpected happened"}
       end)
 
-      assert {:error, "something unexpected happened"} ==
+      assert {:error,
+              %Humaans.Error{type: :network_error, reason: "something unexpected happened"}} =
                Humaans.Companies.list(client)
     end
   end

--- a/test/humaans/compensation_types_test.exs
+++ b/test/humaans/compensation_types_test.exs
@@ -57,7 +57,7 @@ defmodule Humaans.CompensationTypesTest do
         {:ok, %{status: 404, body: %{"error" => "Compensation Type not found"}}}
       end)
 
-      assert {:error, {404, %{"error" => "Compensation Type not found"}}} ==
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
                Humaans.CompensationTypes.list(client)
     end
 
@@ -67,7 +67,8 @@ defmodule Humaans.CompensationTypesTest do
         {:error, "something unexpected happened"}
       end)
 
-      assert {:error, "something unexpected happened"} ==
+      assert {:error,
+              %Humaans.Error{type: :network_error, reason: "something unexpected happened"}} =
                Humaans.CompensationTypes.list(client)
     end
   end

--- a/test/humaans/compensations_test.exs
+++ b/test/humaans/compensations_test.exs
@@ -69,7 +69,7 @@ defmodule Humaans.CompensationsTest do
         {:ok, %{status: 404, body: %{"error" => "Compensation not found"}}}
       end)
 
-      assert {:error, {404, %{"error" => "Compensation not found"}}} ==
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
                Humaans.Compensations.list(client)
     end
 
@@ -79,7 +79,8 @@ defmodule Humaans.CompensationsTest do
         {:error, "something unexpected happened"}
       end)
 
-      assert {:error, "something unexpected happened"} ==
+      assert {:error,
+              %Humaans.Error{type: :network_error, reason: "something unexpected happened"}} =
                Humaans.Compensations.list(client)
     end
   end

--- a/test/humaans/people_test.exs
+++ b/test/humaans/people_test.exs
@@ -214,7 +214,7 @@ defmodule Humaans.PeopleTest do
         {:ok, %{status: 404, body: %{"error" => "Person not found"}}}
       end)
 
-      assert {:error, {404, %{"error" => "Person not found"}}} ==
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
                Humaans.People.list(client)
     end
 
@@ -224,7 +224,8 @@ defmodule Humaans.PeopleTest do
         {:error, "something unexpected happened"}
       end)
 
-      assert {:error, "something unexpected happened"} ==
+      assert {:error,
+              %Humaans.Error{type: :network_error, reason: "something unexpected happened"}} =
                Humaans.People.list(client)
     end
   end

--- a/test/humaans/response_handler_test.exs
+++ b/test/humaans/response_handler_test.exs
@@ -26,14 +26,19 @@ defmodule Humaans.ResponseHandlerTest do
     test "correctly handles error response" do
       response = {:ok, %{status: 422, body: %{"error" => "validation_failed"}}}
 
-      assert {:error, {422, %{"error" => "validation_failed"}}} =
+      assert {:error,
+              %Humaans.Error{
+                type: :api_error,
+                status: 422,
+                body: %{"error" => "validation_failed"}
+              }} =
                ResponseHandler.handle_list_response(response, MockResource)
     end
 
     test "passes through connection errors" do
       response = {:error, %{reason: :timeout}}
 
-      assert {:error, %{reason: :timeout}} =
+      assert {:error, %Humaans.Error{type: :network_error, reason: %{reason: :timeout}}} =
                ResponseHandler.handle_list_response(response, MockResource)
     end
   end
@@ -49,14 +54,15 @@ defmodule Humaans.ResponseHandlerTest do
     test "correctly handles error response" do
       response = {:ok, %{status: 404, body: %{"error" => "not_found"}}}
 
-      assert {:error, {404, %{"error" => "not_found"}}} =
+      assert {:error,
+              %Humaans.Error{type: :api_error, status: 404, body: %{"error" => "not_found"}}} =
                ResponseHandler.handle_resource_response(response, MockResource)
     end
 
     test "passes through connection errors" do
       response = {:error, %{reason: :nxdomain}}
 
-      assert {:error, %{reason: :nxdomain}} =
+      assert {:error, %Humaans.Error{type: :network_error, reason: %{reason: :nxdomain}}} =
                ResponseHandler.handle_resource_response(response, MockResource)
     end
   end
@@ -72,14 +78,15 @@ defmodule Humaans.ResponseHandlerTest do
     test "correctly handles error response" do
       response = {:ok, %{status: 403, body: %{"error" => "forbidden"}}}
 
-      assert {:error, {403, %{"error" => "forbidden"}}} =
+      assert {:error,
+              %Humaans.Error{type: :api_error, status: 403, body: %{"error" => "forbidden"}}} =
                ResponseHandler.handle_delete_response(response)
     end
 
     test "passes through connection errors" do
       response = {:error, %{reason: :econnrefused}}
 
-      assert {:error, %{reason: :econnrefused}} =
+      assert {:error, %Humaans.Error{type: :network_error, reason: %{reason: :econnrefused}}} =
                ResponseHandler.handle_delete_response(response)
     end
   end
@@ -102,14 +109,15 @@ defmodule Humaans.ResponseHandlerTest do
     test "correctly handles error response" do
       response = {:ok, %{status: 500, body: %{"error" => "server_error"}}}
 
-      assert {:error, {500, %{"error" => "server_error"}}} =
+      assert {:error,
+              %Humaans.Error{type: :api_error, status: 500, body: %{"error" => "server_error"}}} =
                ResponseHandler.handle_response(response, fn _ -> "processed" end)
     end
 
     test "passes through connection errors" do
       response = {:error, "connection_error"}
 
-      assert {:error, "connection_error"} =
+      assert {:error, %Humaans.Error{type: :network_error, reason: "connection_error"}} =
                ResponseHandler.handle_response(response, fn _ -> "processed" end)
     end
   end

--- a/test/humaans/timesheet_entries_test.exs
+++ b/test/humaans/timesheet_entries_test.exs
@@ -73,7 +73,7 @@ defmodule Humaans.TimesheetEntriesTest do
         {:ok, %{status: 404, body: %{"error" => "Timesheet Entry not found"}}}
       end)
 
-      assert {:error, {404, %{"error" => "Timesheet Entry not found"}}} ==
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
                Humaans.TimesheetEntries.list(client)
     end
 
@@ -83,7 +83,8 @@ defmodule Humaans.TimesheetEntriesTest do
         {:error, "something unexpected happened"}
       end)
 
-      assert {:error, "something unexpected happened"} ==
+      assert {:error,
+              %Humaans.Error{type: :network_error, reason: "something unexpected happened"}} =
                Humaans.TimesheetEntries.list(client)
     end
   end

--- a/test/humaans/timesheet_submissions_test.exs
+++ b/test/humaans/timesheet_submissions_test.exs
@@ -79,7 +79,7 @@ defmodule Humaans.TimesheetSubmissionsTest do
         {:ok, %{status: 404, body: %{"error" => "Timesheet Submission not found"}}}
       end)
 
-      assert {:error, {404, %{"error" => "Timesheet Submission not found"}}} ==
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
                Humaans.TimesheetSubmissions.list(client)
     end
 
@@ -89,7 +89,8 @@ defmodule Humaans.TimesheetSubmissionsTest do
         {:error, "something unexpected happened"}
       end)
 
-      assert {:error, "something unexpected happened"} ==
+      assert {:error,
+              %Humaans.Error{type: :network_error, reason: "something unexpected happened"}} =
                Humaans.TimesheetSubmissions.list(client)
     end
   end


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Add `Humaans.Error` exception struct with `:api_error` and `:network_error` types
- Update `Humaans.ResponseHandler` to return `%Humaans.Error{}` instead of raw `{:error, {status, body}}` tuples
- Update `@spec` and `@type` definitions across all resource modules to reflect the new error type
- Update tests to assert on the structured error type

Callers can now pattern match on `%Humaans.Error{type: :api_error, status: 404}` rather than parsing `{404, body}` tuples, making error handling more robust:

```elixir
case Humaans.People.retrieve(client, id) do
  {:ok, person} -> person
  {:error, %Humaans.Error{type: :api_error, status: 404}} -> :not_found
  {:error, %Humaans.Error{type: :api_error, status: 401}} -> :unauthorized
  {:error, %Humaans.Error{type: :network_error, reason: reason}} -> {:network_failure, reason}
end
```

> [!IMPORTANT]
> This is a breaking change. Any code currently matching on `{:error, {status, body}}` tuples must be updated to match on `%Humaans.Error{}` structs.