### PR TITLE
feat: parse ISO 8601 date and datetime strings into native Elixir types

### DIFF
--- a/lib/humaans/resources/bank_account.ex
+++ b/lib/humaans/resources/bank_account.ex
@@ -16,7 +16,14 @@ defmodule Humaans.Resources.BankAccount do
     :updated_at
   ]
 
-  use ExConstructor
+  use ExConstructor, :build
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
 
   @type t :: %__MODULE__{
           id: binary | nil,
@@ -27,7 +34,26 @@ defmodule Humaans.Resources.BankAccount do
           swift_code: binary | nil,
           sort_code: binary | nil,
           routing_number: binary | nil,
-          created_at: binary | nil,
-          updated_at: binary | nil
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
         }
+
+  defp parse_datetime(struct, field) do
+    case Map.get(struct, field) do
+      nil ->
+        struct
+
+      "" ->
+        struct
+
+      value when is_binary(value) ->
+        case DateTime.from_iso8601(value) do
+          {:ok, datetime, _offset} -> Map.put(struct, field, datetime)
+          {:error, _} -> struct
+        end
+
+      _ ->
+        struct
+    end
+  end
 end

--- a/lib/humaans/resources/bank_account.ex
+++ b/lib/humaans/resources/bank_account.ex
@@ -18,6 +18,8 @@ defmodule Humaans.Resources.BankAccount do
 
   use ExConstructor, :build
 
+  import Humaans.Resources.Timestamps
+
   def new(data) do
     data
     |> build()
@@ -37,23 +39,4 @@ defmodule Humaans.Resources.BankAccount do
           created_at: DateTime.t() | nil,
           updated_at: DateTime.t() | nil
         }
-
-  defp parse_datetime(struct, field) do
-    case Map.get(struct, field) do
-      nil ->
-        struct
-
-      "" ->
-        struct
-
-      value when is_binary(value) ->
-        case DateTime.from_iso8601(value) do
-          {:ok, datetime, _offset} -> Map.put(struct, field, datetime)
-          {:error, _} -> struct
-        end
-
-      _ ->
-        struct
-    end
-  end
 end

--- a/lib/humaans/resources/company.ex
+++ b/lib/humaans/resources/company.ex
@@ -19,7 +19,15 @@ defmodule Humaans.Resources.Company do
     :updated_at
   ]
 
-  use ExConstructor
+  use ExConstructor, :build
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_date(:trial_end_date)
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
 
   @type payment_status :: :requires_action | :past_due | :ok
   @type status :: :terms | :trialing | :expired | :active | :suspended
@@ -27,7 +35,7 @@ defmodule Humaans.Resources.Company do
           id: binary | nil,
           name: binary | nil,
           domains: [String.t()] | nil,
-          trial_end_date: binary | nil,
+          trial_end_date: Date.t() | nil,
           status: status(),
           payment_status: payment_status(),
           package: binary | nil,
@@ -35,7 +43,45 @@ defmodule Humaans.Resources.Company do
           autogenerate_employee_id: boolean,
           autogenerate_employee_id_for_new_hires: boolean,
           next_employee_id: pos_integer,
-          created_at: binary | nil,
-          updated_at: binary | nil
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
         }
+
+  defp parse_date(struct, field) do
+    case Map.get(struct, field) do
+      nil ->
+        struct
+
+      "" ->
+        struct
+
+      value when is_binary(value) ->
+        case Date.from_iso8601(value) do
+          {:ok, date} -> Map.put(struct, field, date)
+          {:error, _} -> struct
+        end
+
+      _ ->
+        struct
+    end
+  end
+
+  defp parse_datetime(struct, field) do
+    case Map.get(struct, field) do
+      nil ->
+        struct
+
+      "" ->
+        struct
+
+      value when is_binary(value) ->
+        case DateTime.from_iso8601(value) do
+          {:ok, datetime, _offset} -> Map.put(struct, field, datetime)
+          {:error, _} -> struct
+        end
+
+      _ ->
+        struct
+    end
+  end
 end

--- a/lib/humaans/resources/company.ex
+++ b/lib/humaans/resources/company.ex
@@ -21,6 +21,8 @@ defmodule Humaans.Resources.Company do
 
   use ExConstructor, :build
 
+  import Humaans.Resources.Timestamps
+
   def new(data) do
     data
     |> build()
@@ -46,42 +48,4 @@ defmodule Humaans.Resources.Company do
           created_at: DateTime.t() | nil,
           updated_at: DateTime.t() | nil
         }
-
-  defp parse_date(struct, field) do
-    case Map.get(struct, field) do
-      nil ->
-        struct
-
-      "" ->
-        struct
-
-      value when is_binary(value) ->
-        case Date.from_iso8601(value) do
-          {:ok, date} -> Map.put(struct, field, date)
-          {:error, _} -> struct
-        end
-
-      _ ->
-        struct
-    end
-  end
-
-  defp parse_datetime(struct, field) do
-    case Map.get(struct, field) do
-      nil ->
-        struct
-
-      "" ->
-        struct
-
-      value when is_binary(value) ->
-        case DateTime.from_iso8601(value) do
-          {:ok, datetime, _offset} -> Map.put(struct, field, datetime)
-          {:error, _} -> struct
-        end
-
-      _ ->
-        struct
-    end
-  end
 end

--- a/lib/humaans/resources/compensation.ex
+++ b/lib/humaans/resources/compensation.ex
@@ -18,7 +18,16 @@ defmodule Humaans.Resources.Compensation do
     :updated_at
   ]
 
-  use ExConstructor
+  use ExConstructor, :build
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_date(:effective_date)
+    |> parse_date(:end_date)
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
 
   @type base_type :: :salary | :bonus | :commission | :equity | :custom
   @type t :: %__MODULE__{
@@ -29,10 +38,48 @@ defmodule Humaans.Resources.Compensation do
           currency: binary,
           period: binary,
           note: binary,
-          effective_date: binary,
-          end_date: binary,
+          effective_date: Date.t() | nil,
+          end_date: Date.t() | nil,
           end_reason: binary,
-          created_at: binary,
-          updated_at: binary
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
         }
+
+  defp parse_date(struct, field) do
+    case Map.get(struct, field) do
+      nil ->
+        struct
+
+      "" ->
+        struct
+
+      value when is_binary(value) ->
+        case Date.from_iso8601(value) do
+          {:ok, date} -> Map.put(struct, field, date)
+          {:error, _} -> struct
+        end
+
+      _ ->
+        struct
+    end
+  end
+
+  defp parse_datetime(struct, field) do
+    case Map.get(struct, field) do
+      nil ->
+        struct
+
+      "" ->
+        struct
+
+      value when is_binary(value) ->
+        case DateTime.from_iso8601(value) do
+          {:ok, datetime, _offset} -> Map.put(struct, field, datetime)
+          {:error, _} -> struct
+        end
+
+      _ ->
+        struct
+    end
+  end
 end

--- a/lib/humaans/resources/compensation.ex
+++ b/lib/humaans/resources/compensation.ex
@@ -20,6 +20,8 @@ defmodule Humaans.Resources.Compensation do
 
   use ExConstructor, :build
 
+  import Humaans.Resources.Timestamps
+
   def new(data) do
     data
     |> build()
@@ -44,42 +46,4 @@ defmodule Humaans.Resources.Compensation do
           created_at: DateTime.t() | nil,
           updated_at: DateTime.t() | nil
         }
-
-  defp parse_date(struct, field) do
-    case Map.get(struct, field) do
-      nil ->
-        struct
-
-      "" ->
-        struct
-
-      value when is_binary(value) ->
-        case Date.from_iso8601(value) do
-          {:ok, date} -> Map.put(struct, field, date)
-          {:error, _} -> struct
-        end
-
-      _ ->
-        struct
-    end
-  end
-
-  defp parse_datetime(struct, field) do
-    case Map.get(struct, field) do
-      nil ->
-        struct
-
-      "" ->
-        struct
-
-      value when is_binary(value) ->
-        case DateTime.from_iso8601(value) do
-          {:ok, datetime, _offset} -> Map.put(struct, field, datetime)
-          {:error, _} -> struct
-        end
-
-      _ ->
-        struct
-    end
-  end
 end

--- a/lib/humaans/resources/compensation_type.ex
+++ b/lib/humaans/resources/compensation_type.ex
@@ -12,7 +12,14 @@ defmodule Humaans.Resources.CompensationType do
     :updated_at
   ]
 
-  use ExConstructor
+  use ExConstructor, :build
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
 
   @type base_type :: :salary | :bonus | :commission | :equity | :custom
   @type t :: %__MODULE__{
@@ -20,7 +27,26 @@ defmodule Humaans.Resources.CompensationType do
           company_id: binary,
           name: binary | nil,
           base_type: base_type(),
-          created_at: binary,
-          updated_at: binary
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
         }
+
+  defp parse_datetime(struct, field) do
+    case Map.get(struct, field) do
+      nil ->
+        struct
+
+      "" ->
+        struct
+
+      value when is_binary(value) ->
+        case DateTime.from_iso8601(value) do
+          {:ok, datetime, _offset} -> Map.put(struct, field, datetime)
+          {:error, _} -> struct
+        end
+
+      _ ->
+        struct
+    end
+  end
 end

--- a/lib/humaans/resources/compensation_type.ex
+++ b/lib/humaans/resources/compensation_type.ex
@@ -14,6 +14,8 @@ defmodule Humaans.Resources.CompensationType do
 
   use ExConstructor, :build
 
+  import Humaans.Resources.Timestamps
+
   def new(data) do
     data
     |> build()
@@ -30,23 +32,4 @@ defmodule Humaans.Resources.CompensationType do
           created_at: DateTime.t() | nil,
           updated_at: DateTime.t() | nil
         }
-
-  defp parse_datetime(struct, field) do
-    case Map.get(struct, field) do
-      nil ->
-        struct
-
-      "" ->
-        struct
-
-      value when is_binary(value) ->
-        case DateTime.from_iso8601(value) do
-          {:ok, datetime, _offset} -> Map.put(struct, field, datetime)
-          {:error, _} -> struct
-        end
-
-      _ ->
-        struct
-    end
-  end
 end

--- a/lib/humaans/resources/person.ex
+++ b/lib/humaans/resources/person.ex
@@ -75,6 +75,8 @@ defmodule Humaans.Resources.Person do
 
   use ExConstructor, :build
 
+  import Humaans.Resources.Timestamps
+
   def new(data) do
     data
     |> build()
@@ -161,42 +163,4 @@ defmodule Humaans.Resources.Person do
           created_at: DateTime.t() | nil,
           updated_at: DateTime.t() | nil
         }
-
-  defp parse_date(struct, field) do
-    case Map.get(struct, field) do
-      nil ->
-        struct
-
-      "" ->
-        struct
-
-      value when is_binary(value) ->
-        case Date.from_iso8601(value) do
-          {:ok, date} -> Map.put(struct, field, date)
-          {:error, _} -> struct
-        end
-
-      _ ->
-        struct
-    end
-  end
-
-  defp parse_datetime(struct, field) do
-    case Map.get(struct, field) do
-      nil ->
-        struct
-
-      "" ->
-        struct
-
-      value when is_binary(value) ->
-        case DateTime.from_iso8601(value) do
-          {:ok, datetime, _offset} -> Map.put(struct, field, datetime)
-          {:error, _} -> struct
-        end
-
-      _ ->
-        struct
-    end
-  end
 end

--- a/lib/humaans/resources/person.ex
+++ b/lib/humaans/resources/person.ex
@@ -73,7 +73,21 @@ defmodule Humaans.Resources.Person do
     :updated_at
   ]
 
-  use ExConstructor
+  use ExConstructor, :build
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_date(:birthday)
+    |> parse_date(:employment_start_date)
+    |> parse_date(:first_working_day)
+    |> parse_date(:employment_end_date)
+    |> parse_date(:last_working_day)
+    |> parse_date(:probation_end_date)
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+    |> parse_datetime(:seen_documents_at)
+  end
 
   @typep leaving_reason :: :dismissed | :resigned | :redundancy | :contract_ended | :other | nil
   @typep status :: :active | :offboarded | :new_hire
@@ -98,7 +112,7 @@ defmodule Humaans.Resources.Person do
           personal_phone_number: binary | nil,
           formatted_personal_phone_number: binary | nil,
           gender: binary,
-          birthday: binary,
+          birthday: Date.t() | nil,
           profile_photo_id: binary,
           profile_photo: map | nil,
           nationality: binary,
@@ -116,11 +130,11 @@ defmodule Humaans.Resources.Person do
           linked_in: binary,
           twitter: binary,
           github: binary,
-          employment_start_date: binary,
-          first_working_day: binary,
-          employment_end_date: binary | nil,
-          last_working_day: binary | nil,
-          probation_end_date: binary | nil,
+          employment_start_date: Date.t() | nil,
+          first_working_day: Date.t() | nil,
+          employment_end_date: Date.t() | nil,
+          last_working_day: Date.t() | nil,
+          probation_end_date: Date.t() | nil,
           turnover_impact: binary | nil,
           working_days: [working_day()],
           public_holiday_calendar_id: binary,
@@ -137,14 +151,52 @@ defmodule Humaans.Resources.Person do
           is_work_email_hidden: boolean,
           calendar_feed_token: binary | nil,
           role: binary,
-          seen_documents_at: binary | nil,
+          seen_documents_at: DateTime.t() | nil,
           source: binary | nil,
           source_id: binary | nil,
           timezone: binary,
           payroll_provider: binary | nil,
           is_birthday_hidden: boolean,
           demo: boolean,
-          created_at: binary,
-          updated_at: binary
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
         }
+
+  defp parse_date(struct, field) do
+    case Map.get(struct, field) do
+      nil ->
+        struct
+
+      "" ->
+        struct
+
+      value when is_binary(value) ->
+        case Date.from_iso8601(value) do
+          {:ok, date} -> Map.put(struct, field, date)
+          {:error, _} -> struct
+        end
+
+      _ ->
+        struct
+    end
+  end
+
+  defp parse_datetime(struct, field) do
+    case Map.get(struct, field) do
+      nil ->
+        struct
+
+      "" ->
+        struct
+
+      value when is_binary(value) ->
+        case DateTime.from_iso8601(value) do
+          {:ok, datetime, _offset} -> Map.put(struct, field, datetime)
+          {:error, _} -> struct
+        end
+
+      _ ->
+        struct
+    end
+  end
 end

--- a/lib/humaans/resources/timesheet_entry.ex
+++ b/lib/humaans/resources/timesheet_entry.ex
@@ -16,6 +16,8 @@ defmodule Humaans.Resources.TimesheetEntry do
 
   use ExConstructor, :build
 
+  import Humaans.Resources.Timestamps
+
   def new(data) do
     data
     |> build()
@@ -34,42 +36,4 @@ defmodule Humaans.Resources.TimesheetEntry do
           created_at: DateTime.t() | nil,
           updated_at: DateTime.t() | nil
         }
-
-  defp parse_date(struct, field) do
-    case Map.get(struct, field) do
-      nil ->
-        struct
-
-      "" ->
-        struct
-
-      value when is_binary(value) ->
-        case Date.from_iso8601(value) do
-          {:ok, date} -> Map.put(struct, field, date)
-          {:error, _} -> struct
-        end
-
-      _ ->
-        struct
-    end
-  end
-
-  defp parse_datetime(struct, field) do
-    case Map.get(struct, field) do
-      nil ->
-        struct
-
-      "" ->
-        struct
-
-      value when is_binary(value) ->
-        case DateTime.from_iso8601(value) do
-          {:ok, datetime, _offset} -> Map.put(struct, field, datetime)
-          {:error, _} -> struct
-        end
-
-      _ ->
-        struct
-    end
-  end
 end

--- a/lib/humaans/resources/timesheet_entry.ex
+++ b/lib/humaans/resources/timesheet_entry.ex
@@ -14,16 +14,62 @@ defmodule Humaans.Resources.TimesheetEntry do
     :updated_at
   ]
 
-  use ExConstructor
+  use ExConstructor, :build
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_date(:date)
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
 
   @type t :: %__MODULE__{
           id: binary,
           person_id: binary,
-          date: binary,
+          date: Date.t() | nil,
           start_time: binary,
           end_time: binary,
           duration: %{hours: integer, minutes: integer} | nil,
-          created_at: binary,
-          updated_at: binary
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
         }
+
+  defp parse_date(struct, field) do
+    case Map.get(struct, field) do
+      nil ->
+        struct
+
+      "" ->
+        struct
+
+      value when is_binary(value) ->
+        case Date.from_iso8601(value) do
+          {:ok, date} -> Map.put(struct, field, date)
+          {:error, _} -> struct
+        end
+
+      _ ->
+        struct
+    end
+  end
+
+  defp parse_datetime(struct, field) do
+    case Map.get(struct, field) do
+      nil ->
+        struct
+
+      "" ->
+        struct
+
+      value when is_binary(value) ->
+        case DateTime.from_iso8601(value) do
+          {:ok, datetime, _offset} -> Map.put(struct, field, datetime)
+          {:error, _} -> struct
+        end
+
+      _ ->
+        struct
+    end
+  end
 end

--- a/lib/humaans/resources/timesheet_submission.ex
+++ b/lib/humaans/resources/timesheet_submission.ex
@@ -19,21 +19,70 @@ defmodule Humaans.Resources.TimesheetSubmission do
     :updated_at
   ]
 
-  use ExConstructor
+  use ExConstructor, :build
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_date(:start_date)
+    |> parse_date(:end_date)
+    |> parse_datetime(:submitted_at)
+    |> parse_datetime(:reviewed_at)
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
 
   @type t :: %__MODULE__{
           id: binary,
           person_id: binary,
-          start_date: binary,
-          end_date: binary,
+          start_date: Date.t() | nil,
+          end_date: Date.t() | nil,
           status: :pending | :approved | :rejected,
-          submitted_at: binary,
+          submitted_at: DateTime.t() | nil,
           reviewed_by: binary,
-          reviewed_at: binary,
+          reviewed_at: DateTime.t() | nil,
           changes_requested: binary | nil,
           duration_as_time: %{hours: integer, minutes: integer} | nil,
           duration_as_days: integer | nil,
-          created_at: binary,
-          updated_at: binary
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
         }
+
+  defp parse_date(struct, field) do
+    case Map.get(struct, field) do
+      nil ->
+        struct
+
+      "" ->
+        struct
+
+      value when is_binary(value) ->
+        case Date.from_iso8601(value) do
+          {:ok, date} -> Map.put(struct, field, date)
+          {:error, _} -> struct
+        end
+
+      _ ->
+        struct
+    end
+  end
+
+  defp parse_datetime(struct, field) do
+    case Map.get(struct, field) do
+      nil ->
+        struct
+
+      "" ->
+        struct
+
+      value when is_binary(value) ->
+        case DateTime.from_iso8601(value) do
+          {:ok, datetime, _offset} -> Map.put(struct, field, datetime)
+          {:error, _} -> struct
+        end
+
+      _ ->
+        struct
+    end
+  end
 end

--- a/lib/humaans/resources/timesheet_submission.ex
+++ b/lib/humaans/resources/timesheet_submission.ex
@@ -21,6 +21,8 @@ defmodule Humaans.Resources.TimesheetSubmission do
 
   use ExConstructor, :build
 
+  import Humaans.Resources.Timestamps
+
   def new(data) do
     data
     |> build()
@@ -47,42 +49,4 @@ defmodule Humaans.Resources.TimesheetSubmission do
           created_at: DateTime.t() | nil,
           updated_at: DateTime.t() | nil
         }
-
-  defp parse_date(struct, field) do
-    case Map.get(struct, field) do
-      nil ->
-        struct
-
-      "" ->
-        struct
-
-      value when is_binary(value) ->
-        case Date.from_iso8601(value) do
-          {:ok, date} -> Map.put(struct, field, date)
-          {:error, _} -> struct
-        end
-
-      _ ->
-        struct
-    end
-  end
-
-  defp parse_datetime(struct, field) do
-    case Map.get(struct, field) do
-      nil ->
-        struct
-
-      "" ->
-        struct
-
-      value when is_binary(value) ->
-        case DateTime.from_iso8601(value) do
-          {:ok, datetime, _offset} -> Map.put(struct, field, datetime)
-          {:error, _} -> struct
-        end
-
-      _ ->
-        struct
-    end
-  end
 end

--- a/lib/humaans/resources/timestamps.ex
+++ b/lib/humaans/resources/timestamps.ex
@@ -1,0 +1,41 @@
+defmodule Humaans.Resources.Timestamps do
+  @moduledoc false
+
+  def parse_date(struct, field) do
+    case Map.get(struct, field) do
+      nil ->
+        struct
+
+      "" ->
+        struct
+
+      value when is_binary(value) ->
+        case Date.from_iso8601(value) do
+          {:ok, date} -> Map.put(struct, field, date)
+          {:error, _} -> struct
+        end
+
+      _ ->
+        struct
+    end
+  end
+
+  def parse_datetime(struct, field) do
+    case Map.get(struct, field) do
+      nil ->
+        struct
+
+      "" ->
+        struct
+
+      value when is_binary(value) ->
+        case DateTime.from_iso8601(value) do
+          {:ok, datetime, _offset} -> Map.put(struct, field, datetime)
+          {:error, _} -> struct
+        end
+
+      _ ->
+        struct
+    end
+  end
+end

--- a/test/humaans/bank_accounts_test.exs
+++ b/test/humaans/bank_accounts_test.exs
@@ -55,8 +55,8 @@ defmodule Humaans.BankAccountsTest do
       assert response.swift_code == nil
       assert response.sort_code == "00-00-00"
       assert response.routing_number == nil
-      assert response.created_at == "2020-01-28T08:44:42.000Z"
-      assert response.updated_at == "2020-01-29T14:52:21.000Z"
+      assert response.created_at == ~U[2020-01-28 08:44:42.000Z]
+      assert response.updated_at == ~U[2020-01-29 14:52:21.000Z]
     end
 
     test "returns error when resource is not found", %{client: client} do
@@ -147,8 +147,8 @@ defmodule Humaans.BankAccountsTest do
       assert response.swift_code == nil
       assert response.sort_code == "00-00-00"
       assert response.routing_number == nil
-      assert response.created_at == "2020-01-28T08:44:42.000Z"
-      assert response.updated_at == "2020-01-29T14:52:21.000Z"
+      assert response.created_at == ~U[2020-01-28 08:44:42.000Z]
+      assert response.updated_at == ~U[2020-01-29 14:52:21.000Z]
     end
   end
 
@@ -194,8 +194,8 @@ defmodule Humaans.BankAccountsTest do
       assert response.swift_code == nil
       assert response.sort_code == "00-00-00"
       assert response.routing_number == nil
-      assert response.created_at == "2020-01-28T08:44:42.000Z"
-      assert response.updated_at == "2020-01-29T14:52:21.000Z"
+      assert response.created_at == ~U[2020-01-28 08:44:42.000Z]
+      assert response.updated_at == ~U[2020-01-29 14:52:21.000Z]
     end
   end
 

--- a/test/humaans/companies_test.exs
+++ b/test/humaans/companies_test.exs
@@ -50,13 +50,13 @@ defmodule Humaans.CompaniesTest do
       assert response.id == "uoWtfpDIMI2IZ8doGK7kkCwS"
       assert response.name == "Acme"
       assert response.domains == []
-      assert response.trial_end_date == "2020-01-30"
+      assert response.trial_end_date == ~D[2020-01-30]
       assert response.status == "active"
       assert response.payment_status == "ok"
       assert response.package == "growth"
       assert response.is_timesheet_enabled == true
-      assert response.created_at == "2020-01-28T08:44:42.000Z"
-      assert response.updated_at == "2020-01-29T14:52:21.000Z"
+      assert response.created_at == ~U[2020-01-28 08:44:42.000Z]
+      assert response.updated_at == ~U[2020-01-29 14:52:21.000Z]
     end
 
     test "returns error when resource is not found", %{client: client} do
@@ -111,13 +111,13 @@ defmodule Humaans.CompaniesTest do
       assert response.id == "uoWtfpDIMI2IZ8doGK7kkCwS"
       assert response.name == "Acme"
       assert response.domains == []
-      assert response.trial_end_date == "2020-01-30"
+      assert response.trial_end_date == ~D[2020-01-30]
       assert response.status == "active"
       assert response.payment_status == "ok"
       assert response.package == "growth"
       assert response.is_timesheet_enabled == true
-      assert response.created_at == "2020-01-28T08:44:42.000Z"
-      assert response.updated_at == "2020-01-29T14:52:21.000Z"
+      assert response.created_at == ~U[2020-01-28 08:44:42.000Z]
+      assert response.updated_at == ~U[2020-01-29 14:52:21.000Z]
     end
   end
 
@@ -154,13 +154,13 @@ defmodule Humaans.CompaniesTest do
       assert response.id == "uoWtfpDIMI2IZ8doGK7kkCwS"
       assert response.name == "Meac"
       assert response.domains == []
-      assert response.trial_end_date == "2020-01-30"
+      assert response.trial_end_date == ~D[2020-01-30]
       assert response.status == "active"
       assert response.payment_status == "ok"
       assert response.package == "growth"
       assert response.is_timesheet_enabled == true
-      assert response.created_at == "2020-01-28T08:44:42.000Z"
-      assert response.updated_at == "2020-01-29T14:52:21.000Z"
+      assert response.created_at == ~U[2020-01-28 08:44:42.000Z]
+      assert response.updated_at == ~U[2020-01-29 14:52:21.000Z]
     end
   end
 end

--- a/test/humaans/compensation_types_test.exs
+++ b/test/humaans/compensation_types_test.exs
@@ -47,8 +47,8 @@ defmodule Humaans.CompensationTypesTest do
       assert response.company_id == "T7uqPFK7am4lFTZm39AmNuay"
       assert response.name == "Salary"
       assert response.base_type == "salary"
-      assert response.created_at == "2020-01-28T08:44:42.000Z"
-      assert response.updated_at == "2020-01-29T14:52:21.000Z"
+      assert response.created_at == ~U[2020-01-28 08:44:42.000Z]
+      assert response.updated_at == ~U[2020-01-29 14:52:21.000Z]
     end
 
     test "returns error when resource is not found", %{client: client} do
@@ -105,8 +105,8 @@ defmodule Humaans.CompensationTypesTest do
       assert response.company_id == "T7uqPFK7am4lFTZm39AmNuay"
       assert response.name == "Salary"
       assert response.base_type == "salary"
-      assert response.created_at == "2020-01-28T08:44:42.000Z"
-      assert response.updated_at == "2020-01-29T14:52:21.000Z"
+      assert response.created_at == ~U[2020-01-28 08:44:42.000Z]
+      assert response.updated_at == ~U[2020-01-29 14:52:21.000Z]
     end
   end
 
@@ -141,8 +141,8 @@ defmodule Humaans.CompensationTypesTest do
       assert response.company_id == "T7uqPFK7am4lFTZm39AmNuay"
       assert response.name == "Salary"
       assert response.base_type == "salary"
-      assert response.created_at == "2020-01-28T08:44:42.000Z"
-      assert response.updated_at == "2020-01-29T14:52:21.000Z"
+      assert response.created_at == ~U[2020-01-28 08:44:42.000Z]
+      assert response.updated_at == ~U[2020-01-29 14:52:21.000Z]
     end
   end
 
@@ -180,8 +180,8 @@ defmodule Humaans.CompensationTypesTest do
       assert response.company_id == "T7uqPFK7am4lFTZm39AmNuay"
       assert response.name == "New Salary"
       assert response.base_type == "salary"
-      assert response.created_at == "2020-01-28T08:44:42.000Z"
-      assert response.updated_at == "2020-01-29T14:52:21.000Z"
+      assert response.created_at == ~U[2020-01-28 08:44:42.000Z]
+      assert response.updated_at == ~U[2020-01-29 14:52:21.000Z]
     end
   end
 

--- a/test/humaans/compensations_test.exs
+++ b/test/humaans/compensations_test.exs
@@ -56,11 +56,11 @@ defmodule Humaans.CompensationsTest do
       assert response.currency == "EUR"
       assert response.period == "annual"
       assert response.note == "Promotion"
-      assert response.effective_date == "2020-02-15"
+      assert response.effective_date == ~D[2020-02-15]
       assert response.end_date == nil
       assert response.end_reason == nil
-      assert response.created_at == "2020-01-28T08:44:42.000Z"
-      assert response.updated_at == "2020-01-29T14:52:21.000Z"
+      assert response.created_at == ~U[2020-01-28 08:44:42.000Z]
+      assert response.updated_at == ~U[2020-01-29 14:52:21.000Z]
     end
 
     test "returns error when resource is not found", %{client: client} do
@@ -131,11 +131,11 @@ defmodule Humaans.CompensationsTest do
       assert response.currency == "EUR"
       assert response.period == "annual"
       assert response.note == nil
-      assert response.effective_date == "2020-02-15"
+      assert response.effective_date == ~D[2020-02-15]
       assert response.end_date == nil
       assert response.end_reason == nil
-      assert response.created_at == "2020-01-28T08:44:42.000Z"
-      assert response.updated_at == "2020-01-29T14:52:21.000Z"
+      assert response.created_at == ~U[2020-01-28 08:44:42.000Z]
+      assert response.updated_at == ~U[2020-01-29 14:52:21.000Z]
     end
   end
 
@@ -177,11 +177,11 @@ defmodule Humaans.CompensationsTest do
       assert response.currency == "EUR"
       assert response.period == "annual"
       assert response.note == "Promotion"
-      assert response.effective_date == "2020-02-15"
+      assert response.effective_date == ~D[2020-02-15]
       assert response.end_date == nil
       assert response.end_reason == nil
-      assert response.created_at == "2020-01-28T08:44:42.000Z"
-      assert response.updated_at == "2020-01-29T14:52:21.000Z"
+      assert response.created_at == ~U[2020-01-28 08:44:42.000Z]
+      assert response.updated_at == ~U[2020-01-29 14:52:21.000Z]
     end
   end
 
@@ -235,11 +235,11 @@ defmodule Humaans.CompensationsTest do
       assert response.currency == "EUR"
       assert response.period == "annual"
       assert response.note == "Promotion"
-      assert response.effective_date == "2020-02-15"
+      assert response.effective_date == ~D[2020-02-15]
       assert response.end_date == nil
       assert response.end_reason == nil
-      assert response.created_at == "2020-01-28T08:44:42.000Z"
-      assert response.updated_at == "2020-01-29T14:52:21.000Z"
+      assert response.created_at == ~U[2020-01-28 08:44:42.000Z]
+      assert response.updated_at == ~U[2020-01-29 14:52:21.000Z]
     end
   end
 

--- a/test/humaans/people_test.exs
+++ b/test/humaans/people_test.exs
@@ -167,7 +167,7 @@ defmodule Humaans.PeopleTest do
       assert response.personal_phone_number == nil
       assert response.formatted_personal_phone_number == nil
       assert response.gender == "Female"
-      assert response.birthday == "1989-07-28"
+      assert response.birthday == ~D[1989-07-28]
       assert response.profile_photo_id == "Hgi5auXaKsjn2MjuYo1PDk3W"
 
       assert response.profile_photo
@@ -204,8 +204,8 @@ defmodule Humaans.PeopleTest do
       assert response.profile_photo["variants"]["96"] ==
                "https://storage.googleapis.com/humaans-public-prd/Hgi5auXaKsjn2MjuYo1PDk3W@96.jpg"
 
-      assert response.created_at == "2020-01-28T08:44:42.000Z"
-      assert response.updated_at == "2020-01-29T14:52:21.000Z"
+      assert response.created_at == ~U[2020-01-28 08:44:42.000Z]
+      assert response.updated_at == ~U[2020-01-29 14:52:21.000Z]
     end
 
     test "returns error when resource is not found", %{client: client} do
@@ -285,8 +285,8 @@ defmodule Humaans.PeopleTest do
       assert response.birthday == nil
       assert response.profile_photo_id == nil
       assert response.profile_photo == nil
-      assert response.created_at == "2020-01-28T08:44:42.000Z"
-      assert response.updated_at == "2020-01-29T14:52:21.000Z"
+      assert response.created_at == ~U[2020-01-28 08:44:42.000Z]
+      assert response.updated_at == ~U[2020-01-29 14:52:21.000Z]
     end
   end
 
@@ -439,7 +439,7 @@ defmodule Humaans.PeopleTest do
       assert response.personal_phone_number == nil
       assert response.formatted_personal_phone_number == nil
       assert response.gender == "Female"
-      assert response.birthday == "1989-07-28"
+      assert response.birthday == ~D[1989-07-28]
       assert response.profile_photo_id == "Hgi5auXaKsjn2MjuYo1PDk3W"
 
       assert response.profile_photo
@@ -476,8 +476,8 @@ defmodule Humaans.PeopleTest do
       assert response.profile_photo["variants"]["96"] ==
                "https://storage.googleapis.com/humaans-public-prd/Hgi5auXaKsjn2MjuYo1PDk3W@96.jpg"
 
-      assert response.created_at == "2020-01-28T08:44:42.000Z"
-      assert response.updated_at == "2020-01-29T14:52:21.000Z"
+      assert response.created_at == ~U[2020-01-28 08:44:42.000Z]
+      assert response.updated_at == ~U[2020-01-29 14:52:21.000Z]
     end
   end
 
@@ -623,8 +623,8 @@ defmodule Humaans.PeopleTest do
       assert response.last_name == "Wicks"
       assert response.preferred_name == nil
       assert response.preferred_name == nil
-      assert response.created_at == "2020-01-28T08:44:42.000Z"
-      assert response.updated_at == "2020-01-29T14:52:21.000Z"
+      assert response.created_at == ~U[2020-01-28 08:44:42.000Z]
+      assert response.updated_at == ~U[2020-01-29 14:52:21.000Z]
     end
   end
 

--- a/test/humaans/resources/timestamps_test.exs
+++ b/test/humaans/resources/timestamps_test.exs
@@ -1,0 +1,117 @@
+defmodule Humaans.Resources.TimestampsTest do
+  use ExUnit.Case, async: true
+
+  import Humaans.Resources.Timestamps
+
+  describe "parse_date/2" do
+    test "parses a valid ISO 8601 date string" do
+      struct = %{birthday: "1989-07-28"}
+      assert parse_date(struct, :birthday) == %{birthday: ~D[1989-07-28]}
+    end
+
+    test "returns struct unchanged when field is nil" do
+      struct = %{birthday: nil}
+      assert parse_date(struct, :birthday) == struct
+    end
+
+    test "returns struct unchanged when field is empty string" do
+      struct = %{birthday: ""}
+      assert parse_date(struct, :birthday) == struct
+    end
+
+    test "returns struct unchanged when field is already a Date" do
+      struct = %{birthday: ~D[1989-07-28]}
+      assert parse_date(struct, :birthday) == struct
+    end
+
+    test "returns struct unchanged when field is missing" do
+      struct = %{name: "Kelsey"}
+      assert parse_date(struct, :birthday) == struct
+    end
+
+    test "returns struct unchanged when value is an invalid date string" do
+      struct = %{birthday: "not-a-date"}
+      assert parse_date(struct, :birthday) == struct
+    end
+
+    test "returns struct unchanged when value is an invalid date format" do
+      struct = %{birthday: "28-07-1989"}
+      assert parse_date(struct, :birthday) == struct
+    end
+
+    test "parses date at the start of a year" do
+      struct = %{employment_start_date: "2018-01-01"}
+
+      assert parse_date(struct, :employment_start_date) == %{
+               employment_start_date: ~D[2018-01-01]
+             }
+    end
+
+    test "parses date at the end of a year" do
+      struct = %{employment_end_date: "2023-12-31"}
+      assert parse_date(struct, :employment_end_date) == %{employment_end_date: ~D[2023-12-31]}
+    end
+
+    test "does not affect other fields in the struct" do
+      struct = %{name: "Kelsey", birthday: "1989-07-28"}
+      result = parse_date(struct, :birthday)
+      assert result.name == "Kelsey"
+      assert result.birthday == ~D[1989-07-28]
+    end
+  end
+
+  describe "parse_datetime/2" do
+    test "parses a valid ISO 8601 UTC datetime string" do
+      struct = %{created_at: "2021-03-22T10:40:43.951Z"}
+
+      assert parse_datetime(struct, :created_at) == %{
+               created_at: ~U[2021-03-22 10:40:43.951Z]
+             }
+    end
+
+    test "parses a valid ISO 8601 datetime string with offset" do
+      struct = %{created_at: "2021-03-22T11:40:43.951+01:00"}
+      result = parse_datetime(struct, :created_at)
+      assert %DateTime{} = result.created_at
+      assert result.created_at.hour == 10
+      assert result.created_at.minute == 40
+    end
+
+    test "returns struct unchanged when field is nil" do
+      struct = %{created_at: nil}
+      assert parse_datetime(struct, :created_at) == struct
+    end
+
+    test "returns struct unchanged when field is empty string" do
+      struct = %{created_at: ""}
+      assert parse_datetime(struct, :created_at) == struct
+    end
+
+    test "returns struct unchanged when field is already a DateTime" do
+      struct = %{created_at: ~U[2021-03-22 10:40:43Z]}
+      assert parse_datetime(struct, :created_at) == struct
+    end
+
+    test "returns struct unchanged when field is missing" do
+      struct = %{name: "Kelsey"}
+      assert parse_datetime(struct, :created_at) == struct
+    end
+
+    test "returns struct unchanged when value is an invalid datetime string" do
+      struct = %{created_at: "not-a-datetime"}
+      assert parse_datetime(struct, :created_at) == struct
+    end
+
+    test "returns struct unchanged when value is a date-only string" do
+      struct = %{created_at: "2021-03-22"}
+      assert parse_datetime(struct, :created_at) == struct
+    end
+
+    test "does not affect other fields in the struct" do
+      struct = %{name: "Kelsey", created_at: "2021-03-22T10:40:43.951Z"}
+      result = parse_datetime(struct, :created_at)
+      assert result.name == "Kelsey"
+      assert %DateTime{} = result.created_at
+    end
+  end
+end

--- a/test/humaans/timesheet_entries_test.exs
+++ b/test/humaans/timesheet_entries_test.exs
@@ -54,7 +54,7 @@ defmodule Humaans.TimesheetEntriesTest do
 
       assert response.id == "0vUGk85FkSDHXfeOTnXqkk4d"
       assert response.person_id == "IL3vneCYhIx0xrR6um2sy2nW"
-      assert response.date == "2020-04-01"
+      assert response.date == ~D[2020-04-01]
       assert response.start_time == "09:00:00"
       assert response.end_time == "12:30:00"
 
@@ -63,8 +63,8 @@ defmodule Humaans.TimesheetEntriesTest do
                "minutes" => 30
              }
 
-      assert response.created_at == "2020-01-28T08:44:42.000Z"
-      assert response.updated_at == "2020-01-29T14:52:21.000Z"
+      assert response.created_at == ~U[2020-01-28 08:44:42.000Z]
+      assert response.updated_at == ~U[2020-01-29 14:52:21.000Z]
     end
 
     test "returns error when resource is not found", %{client: client} do
@@ -114,10 +114,10 @@ defmodule Humaans.TimesheetEntriesTest do
       assert {:ok, response} = Humaans.TimesheetEntries.create(client, params)
       assert response.id == "new_id"
       assert response.person_id == "IL3vneCYhIx0xrR6um2sy2nW"
-      assert response.date == "2020-04-01"
+      assert response.date == ~D[2020-04-01]
       assert response.start_time == "09:00:00"
-      assert response.created_at == "2020-01-28T08:44:42.000Z"
-      assert response.updated_at == "2020-01-29T14:52:21.000Z"
+      assert response.created_at == ~U[2020-01-28 08:44:42.000Z]
+      assert response.updated_at == ~U[2020-01-29 14:52:21.000Z]
     end
   end
 
@@ -156,19 +156,19 @@ defmodule Humaans.TimesheetEntriesTest do
       assert response.id == "0vUGk85FkSDHXfeOTnXqkk4d"
       assert response.person_id == "IL3vneCYhIx0xrR6um2sy2nW"
       assert response.person_id == "IL3vneCYhIx0xrR6um2sy2nW"
-      assert response.date == "2020-04-01"
+      assert response.date == ~D[2020-04-01]
       assert response.start_time == "09:00:00"
       assert response.end_time == "12:30:00"
-      assert response.created_at == "2020-01-28T08:44:42.000Z"
-      assert response.updated_at == "2020-01-29T14:52:21.000Z"
+      assert response.created_at == ~U[2020-01-28 08:44:42.000Z]
+      assert response.updated_at == ~U[2020-01-29 14:52:21.000Z]
 
       assert response.duration == %{
                "hours" => 127,
                "minutes" => 30
              }
 
-      assert response.created_at == "2020-01-28T08:44:42.000Z"
-      assert response.updated_at == "2020-01-29T14:52:21.000Z"
+      assert response.created_at == ~U[2020-01-28 08:44:42.000Z]
+      assert response.updated_at == ~U[2020-01-29 14:52:21.000Z]
     end
   end
 
@@ -209,7 +209,7 @@ defmodule Humaans.TimesheetEntriesTest do
 
       assert response.id == "0vUGk85FkSDHXfeOTnXqkk4d"
       assert response.person_id == "IL3vneCYhIx0xrR6um2sy2nW"
-      assert response.date == "2020-04-01"
+      assert response.date == ~D[2020-04-01]
       assert response.start_time == "09:00:00"
       assert response.end_time == "12:30:00"
 
@@ -218,8 +218,8 @@ defmodule Humaans.TimesheetEntriesTest do
                "minutes" => 30
              }
 
-      assert response.created_at == "2020-01-28T08:44:42.000Z"
-      assert response.updated_at == "2020-01-29T14:52:21.000Z"
+      assert response.created_at == ~U[2020-01-28 08:44:42.000Z]
+      assert response.updated_at == ~U[2020-01-29 14:52:21.000Z]
     end
   end
 

--- a/test/humaans/timesheet_submissions_test.exs
+++ b/test/humaans/timesheet_submissions_test.exs
@@ -55,12 +55,12 @@ defmodule Humaans.TimesheetSubmissionsTest do
       assert length(responses) == 1
       assert response.id == "Qh1bcl6baOIFPBgJjM0I9wNB"
       assert response.person_id == "IL3vneCYhIx0xrR6um2sy2nW"
-      assert response.start_date == "2020-04-01"
-      assert response.end_date == "2020-04-30"
+      assert response.start_date == ~D[2020-04-01]
+      assert response.end_date == ~D[2020-04-30]
       assert response.status == "pending"
-      assert response.submitted_at == "2020-04-30T17:08:29.290Z"
+      assert response.submitted_at == ~U[2020-04-30 17:08:29.290Z]
       assert response.reviewed_by == "ob4xPcVpGGZm043C7xGMfP1U"
-      assert response.reviewed_at == "2020-04-30T17:08:29.290Z"
+      assert response.reviewed_at == ~U[2020-04-30 17:08:29.290Z]
       assert response.changes_requested == "Missing hours from weekend shift."
 
       assert response.duration_as_time == %{
@@ -69,8 +69,8 @@ defmodule Humaans.TimesheetSubmissionsTest do
              }
 
       assert response.duration_as_days == 23
-      assert response.created_at == "2020-01-28T08:44:42.000Z"
-      assert response.updated_at == "2020-01-29T14:52:21.000Z"
+      assert response.created_at == ~U[2020-01-28 08:44:42.000Z]
+      assert response.updated_at == ~U[2020-01-29 14:52:21.000Z]
     end
 
     test "returns error when resource is not found", %{client: client} do
@@ -120,9 +120,9 @@ defmodule Humaans.TimesheetSubmissionsTest do
       assert {:ok, response} = Humaans.TimesheetSubmissions.create(client, params)
       assert response.id == "new_id"
       assert response.person_id == "IL3vneCYhIx0xrR6um2sy2nW"
-      assert response.start_date == "2020-04-01"
-      assert response.created_at == "2020-01-28T08:44:42.000Z"
-      assert response.updated_at == "2020-01-29T14:52:21.000Z"
+      assert response.start_date == ~D[2020-04-01]
+      assert response.created_at == ~U[2020-01-28 08:44:42.000Z]
+      assert response.updated_at == ~U[2020-01-29 14:52:21.000Z]
     end
   end
 
@@ -165,12 +165,12 @@ defmodule Humaans.TimesheetSubmissionsTest do
 
       assert response.id == "Qh1bcl6baOIFPBgJjM0I9wNB"
       assert response.person_id == "IL3vneCYhIx0xrR6um2sy2nW"
-      assert response.start_date == "2020-04-01"
-      assert response.end_date == "2020-04-30"
+      assert response.start_date == ~D[2020-04-01]
+      assert response.end_date == ~D[2020-04-30]
       assert response.status == "pending"
-      assert response.submitted_at == "2020-04-30T17:08:29.290Z"
+      assert response.submitted_at == ~U[2020-04-30 17:08:29.290Z]
       assert response.reviewed_by == "ob4xPcVpGGZm043C7xGMfP1U"
-      assert response.reviewed_at == "2020-04-30T17:08:29.290Z"
+      assert response.reviewed_at == ~U[2020-04-30 17:08:29.290Z]
       assert response.changes_requested == "Missing hours from weekend shift."
 
       assert response.duration_as_time == %{
@@ -179,8 +179,8 @@ defmodule Humaans.TimesheetSubmissionsTest do
              }
 
       assert response.duration_as_days == 23
-      assert response.created_at == "2020-01-28T08:44:42.000Z"
-      assert response.updated_at == "2020-01-29T14:52:21.000Z"
+      assert response.created_at == ~U[2020-01-28 08:44:42.000Z]
+      assert response.updated_at == ~U[2020-01-29 14:52:21.000Z]
     end
   end
 
@@ -226,12 +226,12 @@ defmodule Humaans.TimesheetSubmissionsTest do
 
       assert response.id == "Qh1bcl6baOIFPBgJjM0I9wNB"
       assert response.person_id == "IL3vneCYhIx0xrR6um2sy2nW"
-      assert response.start_date == "2020-04-01"
-      assert response.end_date == "2020-04-30"
+      assert response.start_date == ~D[2020-04-01]
+      assert response.end_date == ~D[2020-04-30]
       assert response.status == "pending"
-      assert response.submitted_at == "2020-04-30T17:08:29.290Z"
+      assert response.submitted_at == ~U[2020-04-30 17:08:29.290Z]
       assert response.reviewed_by == "ob4xPcVpGGZm043C7xGMfP1U"
-      assert response.reviewed_at == "2020-04-30T17:08:29.290Z"
+      assert response.reviewed_at == ~U[2020-04-30 17:08:29.290Z]
       assert response.changes_requested == "Missing hours from weekend shift."
 
       assert response.duration_as_time == %{
@@ -240,8 +240,8 @@ defmodule Humaans.TimesheetSubmissionsTest do
              }
 
       assert response.duration_as_days == 23
-      assert response.created_at == "2020-01-28T08:44:42.000Z"
-      assert response.updated_at == "2020-01-29T14:52:21.000Z"
+      assert response.created_at == ~U[2020-01-28 08:44:42.000Z]
+      assert response.updated_at == ~U[2020-01-29 14:52:21.000Z]
     end
   end
 


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Parse date fields (e.g. `birthday`, `employment_start_date`, `effective_date`, `date`) into `Date.t()` structs across all resource modules
- Parse datetime fields (e.g. `created_at`, `updated_at`, `submitted_at`) into `DateTime.t()` structs across all resource modules
- Update `@type t` specs to reflect the new types
- Update tests to compare against `~D[...]` and `~U[...]` sigils

No new dependencies are required — parsing uses Elixir's built-in `Date.from_iso8601/1` and `DateTime.from_iso8601/1`. Parsing failures are handled gracefully: if a value cannot be parsed the original string is left in place.

> [!IMPORTANT]
> This is a breaking change. Any code comparing date/datetime fields against strings must be updated.

**Fields changed per resource:**

| Resource | Date fields | DateTime fields |
|---|---|---|
| `Person` | `birthday`, `employment_start_date`, `first_working_day`, `employment_end_date`, `last_working_day`, `probation_end_date` | `created_at`, `updated_at`, `seen_documents_at` |
| `Company` | `trial_end_date` | `created_at`, `updated_at` |
| `BankAccount` | — | `created_at`, `updated_at` |
| `Compensation` | `effective_date`, `end_date` | `created_at`, `updated_at` |
| `CompensationType` | — | `created_at`, `updated_at` |
| `TimesheetEntry` | `date` | `created_at`, `updated_at` |
| `TimesheetSubmission` | `start_date`, `end_date` | `submitted_at`, `reviewed_at`, `created_at`, `updated_at` |