### PR TITLE
feat: add telemetry instrumentation for API requests

### DIFF
--- a/lib/humaans.ex
+++ b/lib/humaans.ex
@@ -54,6 +54,12 @@ defmodule Humaans do
         "email" => "jane.doe@example.com"
       }
       {:ok, new_person} = Humaans.People.create(client, person_params)
+
+  ## Telemetry
+
+  This library emits [`:telemetry`](https://hexdocs.pm/telemetry) events for all
+  API requests. See `Humaans.Telemetry` for the full list of events, measurements,
+  and metadata.
   """
 
   @type t :: %__MODULE__{

--- a/lib/humaans/client.ex
+++ b/lib/humaans/client.ex
@@ -157,6 +157,18 @@ defmodule Humaans.Client do
     url = build_url(client, path)
     opts = Keyword.merge([headers: headers, method: method, url: url], opts)
 
-    client.http_client.request(client, opts)
+    metadata = %{method: method, path: path, url: url}
+
+    :telemetry.span([:humaans, :request], metadata, fn ->
+      result = client.http_client.request(client, opts)
+
+      stop_metadata =
+        case result do
+          {:ok, %{status: status}} -> Map.put(metadata, :status, status)
+          {:error, _} -> Map.put(metadata, :error, true)
+        end
+
+      {result, stop_metadata}
+    end)
   end
 end

--- a/lib/humaans/telemetry.ex
+++ b/lib/humaans/telemetry.ex
@@ -1,0 +1,106 @@
+defmodule Humaans.Telemetry do
+  @moduledoc """
+  Telemetry integration for the Humaans client.
+
+  This library emits [`:telemetry`](https://hexdocs.pm/telemetry) events for
+  every API request made through `Humaans.Client`. Attach handlers to observe
+  latency, status codes, and errors without modifying library code.
+
+  ## Events
+
+  ### `[:humaans, :request, :start]`
+
+  Emitted immediately before the HTTP request is sent.
+
+  **Measurements:**
+
+  | Key              | Type    | Description                             |
+  |------------------|---------|-----------------------------------------|
+  | `:system_time`   | integer | Current system time (native time units) |
+  | `:monotonic_time`| integer | Monotonic time at request start         |
+
+  **Metadata:**
+
+  | Key       | Type   | Description                           |
+  |-----------|--------|---------------------------------------|
+  | `:method` | atom   | HTTP method (`:get`, `:post`, etc.)   |
+  | `:path`   | string | API path (e.g. `"/people"`)           |
+  | `:url`    | string | Full request URL                      |
+
+  ### `[:humaans, :request, :stop]`
+
+  Emitted after a response is received (including error responses).
+
+  **Measurements:**
+
+  | Key              | Type    | Description                              |
+  |------------------|---------|------------------------------------------|
+  | `:duration`      | integer | Request duration in native time units    |
+  | `:monotonic_time`| integer | Monotonic time at request completion     |
+
+  **Metadata:**
+
+  | Key       | Type    | Description                                   |
+  |-----------|---------|-----------------------------------------------|
+  | `:method` | atom    | HTTP method                                   |
+  | `:path`   | string  | API path                                      |
+  | `:url`    | string  | Full request URL                              |
+  | `:status` | integer | HTTP status code (present on successful HTTP) |
+  | `:error`  | boolean | `true` if the HTTP client returned an error   |
+
+  ### `[:humaans, :request, :exception]`
+
+  Emitted if an exception is raised during the request.
+
+  **Measurements:**
+
+  | Key              | Type    | Description                                      |
+  |------------------|---------|--------------------------------------------------|
+  | `:duration`      | integer | Time elapsed before exception (native time units)|
+  | `:monotonic_time`| integer | Monotonic time at exception                      |
+
+  **Metadata:**
+
+  | Key           | Type | Description                              |
+  |---------------|------|------------------------------------------|
+  | `:method`     | atom | HTTP method                              |
+  | `:path`       | string | API path                               |
+  | `:url`        | string | Full request URL                       |
+  | `:kind`       | atom | Exception kind (`:error`, `:exit`, etc.)|
+  | `:reason`     | any  | The exception or reason                  |
+  | `:stacktrace` | list | Exception stacktrace                     |
+
+  ## Usage
+
+  Attach handlers using `:telemetry.attach/4` or `:telemetry.attach_many/4`:
+
+      # Log all completed API requests
+      :telemetry.attach(
+        "humaans-logger",
+        [:humaans, :request, :stop],
+        fn _event, measurements, metadata, _config ->
+          duration_ms =
+            System.convert_time_unit(measurements.duration, :native, :millisecond)
+
+          Logger.info(
+            "Humaans API \#{metadata.method} \#{metadata.path} " <>
+              "-> \#{metadata[:status]} (\#{duration_ms}ms)"
+          )
+        end,
+        nil
+      )
+
+      # Track API errors in your monitoring system
+      :telemetry.attach(
+        "humaans-error-tracker",
+        [:humaans, :request, :stop],
+        fn _event, _measurements, %{error: true} = metadata, _config ->
+          MyMonitoring.increment("humaans.api.error",
+            tags: ["path:\#{metadata.path}"]
+          )
+        end,
+        nil
+      )
+
+  """
+end

--- a/mix.exs
+++ b/mix.exs
@@ -35,6 +35,7 @@ defmodule Humaans.MixProject do
     [
       {:exconstructor, "~> 1.3.0"},
       {:req, "~> 0.5.6"},
+      {:telemetry, "~> 1.0"},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:expublish, "~> 2.5", only: [:dev], runtime: false},

--- a/test/humaans/telemetry_test.exs
+++ b/test/humaans/telemetry_test.exs
@@ -1,0 +1,87 @@
+defmodule Humaans.TelemetryTest do
+  use ExUnit.Case, async: false
+
+  setup do
+    client = Humaans.new(access_token: "test-token", http_client: Humaans.MockHTTPClient)
+    {:ok, client: client}
+  end
+
+  describe "[:humaans, :request, :start]" do
+    test "is emitted before the request", %{client: client} do
+      Mox.expect(Humaans.MockHTTPClient, :request, fn _client, _opts ->
+        {:ok, %{status: 200, body: %{"data" => []}}}
+      end)
+
+      ref = :telemetry_test.attach_event_handlers(self(), [[:humaans, :request, :start]])
+
+      Humaans.People.list(client)
+
+      assert_receive {[:humaans, :request, :start], ^ref, measurements, metadata}
+      assert is_integer(measurements.system_time)
+      assert is_integer(measurements.monotonic_time)
+      assert metadata.method == :get
+      assert metadata.path == "/people"
+      assert String.ends_with?(metadata.url, "/people")
+    end
+  end
+
+  describe "[:humaans, :request, :stop]" do
+    test "is emitted after a successful request", %{client: client} do
+      Mox.expect(Humaans.MockHTTPClient, :request, fn _client, _opts ->
+        {:ok, %{status: 200, body: %{"data" => []}}}
+      end)
+
+      ref = :telemetry_test.attach_event_handlers(self(), [[:humaans, :request, :stop]])
+
+      Humaans.People.list(client)
+
+      assert_receive {[:humaans, :request, :stop], ^ref, measurements, metadata}
+      assert is_integer(measurements.duration)
+      assert measurements.duration > 0
+      assert metadata.method == :get
+      assert metadata.path == "/people"
+      assert metadata.status == 200
+    end
+
+    test "includes status for non-2xx responses", %{client: client} do
+      Mox.expect(Humaans.MockHTTPClient, :request, fn _client, _opts ->
+        {:ok, %{status: 404, body: %{"error" => "not found"}}}
+      end)
+
+      ref = :telemetry_test.attach_event_handlers(self(), [[:humaans, :request, :stop]])
+
+      Humaans.People.retrieve(client, "missing")
+
+      assert_receive {[:humaans, :request, :stop], ^ref, _measurements, metadata}
+      assert metadata.status == 404
+    end
+
+    test "includes error: true for network errors", %{client: client} do
+      Mox.expect(Humaans.MockHTTPClient, :request, fn _client, _opts ->
+        {:error, :econnrefused}
+      end)
+
+      ref = :telemetry_test.attach_event_handlers(self(), [[:humaans, :request, :stop]])
+
+      Humaans.People.list(client)
+
+      assert_receive {[:humaans, :request, :stop], ^ref, _measurements, metadata}
+      assert metadata.error == true
+    end
+
+    test "is emitted for POST requests", %{client: client} do
+      Mox.expect(Humaans.MockHTTPClient, :request, fn _client, _opts ->
+        {:ok, %{status: 201, body: %{"id" => "new-id", "firstName" => "Jane"}}}
+      end)
+
+      ref = :telemetry_test.attach_event_handlers(self(), [[:humaans, :request, :stop]])
+
+      Humaans.People.create(client, %{"firstName" => "Jane"})
+
+      assert_receive {[:humaans, :request, :stop], ^ref, _measurements, metadata}
+      assert metadata.method == :post
+      assert metadata.path == "/people"
+      assert metadata.status == 201
+    end
+  end
+end


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Add `:telemetry ~> 1.0` as a runtime dependency
- Instrument `Humaans.Client` to emit `[:humaans, :request, :start]`, `[:humaans, :request, :stop]`, and `[:humaans, :request, :exception]` events using `:telemetry.span/3`
- Add `Humaans.Telemetry` module documenting all events, measurements, and metadata with usage examples
- Add telemetry tests covering start/stop events for GET, POST, 4xx, and network error cases
- Document telemetry integration in the `Humaans` module

This is a non-breaking, purely additive change. Consumers can attach handlers to observe API call latency, status codes, and errors without modifying any existing code.

```elixir
:telemetry.attach(
  "humaans-logger",
  [:humaans, :request, :stop],
  fn _event, measurements, metadata, _config ->
    duration_ms = System.convert_time_unit(measurements.duration, :native, :millisecond)
    Logger.info("Humaans #{metadata.method} #{metadata.path} -> #{metadata[:status]} (#{duration_ms}ms)")
  end,
  nil
)
```