### PR TITLE
feat: add Humaans.Pagination for page-by-page and streaming iteration

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(rtk ls:*)",
+      "Bash(rtk read:*)",
+      "Bash(rtk git:*)",
+      "WebFetch(domain:api.github.com)",
+      "WebFetch(domain:github.com)"
+    ]
+  }
+}

--- a/lib/humaans.ex
+++ b/lib/humaans.ex
@@ -60,6 +60,19 @@ defmodule Humaans do
   This library emits [`:telemetry`](https://hexdocs.pm/telemetry) events for all
   API requests. See `Humaans.Telemetry` for the full list of events, measurements,
   and metadata.
+
+  ## Pagination
+
+  Use `Humaans.Pagination` to iterate through large result sets without loading
+  everything into memory:
+
+      # Stream all people 50 at a time
+      client
+      |> Humaans.Pagination.stream(&Humaans.People.list/2, page_size: 50)
+      |> Enum.each(fn person -> IO.puts(person.first_name) end)
+
+      # Fetch a specific page
+      {:ok, result} = Humaans.Pagination.page(client, &Humaans.People.list/2, 2, page_size: 25)
   """
 
   @type t :: %__MODULE__{
@@ -146,4 +159,12 @@ defmodule Humaans do
   Returns the module that contains functions for working with timesheet submission resources.
   """
   def timesheet_submissions, do: Humaans.TimesheetSubmissions
+
+  @doc """
+  Access pagination helpers.
+
+  Returns `Humaans.Pagination`, which provides `page/4` for fetching a specific
+  page and `stream/3` for lazily iterating all results.
+  """
+  def pagination, do: Humaans.Pagination
 end

--- a/lib/humaans/pagination.ex
+++ b/lib/humaans/pagination.ex
@@ -1,0 +1,152 @@
+defmodule Humaans.Pagination do
+  @moduledoc """
+  Helpers for paginating through Humaans API list endpoints.
+
+  The Humaans API uses offset-based pagination via `limit` and `skip`
+  parameters. All list endpoints support these parameters.
+
+  ## Page-by-page iteration
+
+  Use `page/4` to fetch a specific page of results:
+
+      client = Humaans.new(access_token: "token")
+
+      {:ok, result} = Humaans.Pagination.page(client, &Humaans.People.list/2, 1, page_size: 25)
+      result.data       # list of Person structs for page 1
+      result.page       # 1
+      result.page_size  # 25
+
+  ## Streaming
+
+  Use `stream/3` to lazily iterate all resources without loading everything
+  into memory at once. Pages are fetched on demand and the stream stops
+  automatically when the last page is reached.
+
+      client
+      |> Humaans.Pagination.stream(&Humaans.People.list/2, page_size: 50)
+      |> Stream.filter(&(&1.status == :active))
+      |> Enum.to_list()
+
+  Any additional options (other than `:page_size`) are forwarded to the
+  `list_fn` as query parameters:
+
+      client
+      |> Humaans.Pagination.stream(
+        &Humaans.Compensations.list/2,
+        page_size: 100,
+        personId: "person-123"
+      )
+      |> Enum.each(&process/1)
+
+  """
+
+  @default_page_size 20
+
+  @type page_result(resource) :: %{
+          data: [resource],
+          page: pos_integer(),
+          page_size: pos_integer()
+        }
+
+  @doc """
+  Fetches a specific page of results from a list endpoint.
+
+  `list_fn` must be a function with arity 2 that accepts a client and a params
+  keyword list and returns `{:ok, [structs]} | {:error, reason}`.
+
+  ## Parameters
+
+  * `client` - Client map created with `Humaans.new/1`
+  * `list_fn` - A 2-arity list function, e.g. `&Humaans.People.list/2`
+  * `page` - Page number, 1-based
+  * `opts` - Options:
+    * `:page_size` - Number of results per page (default: #{@default_page_size})
+    * Any other options are forwarded as query parameters to `list_fn`
+
+  ## Examples
+
+      {:ok, result} = Humaans.Pagination.page(client, &Humaans.People.list/2, 1, page_size: 25)
+      result.data       #=> [%Person{}, ...]
+      result.page       #=> 1
+      result.page_size  #=> 25
+
+  """
+  @spec page(client :: map(), list_fn :: function(), page :: pos_integer(), opts :: keyword()) ::
+          {:ok, page_result(struct())} | {:error, any()}
+  def page(client, list_fn, page_number, opts \\ []) when page_number >= 1 do
+    page_size = Keyword.get(opts, :page_size, @default_page_size)
+    extra_params = Keyword.drop(opts, [:page_size])
+
+    skip = (page_number - 1) * page_size
+    params = Keyword.merge(extra_params, limit: page_size, skip: skip)
+
+    case list_fn.(client, params) do
+      {:ok, data} when is_list(data) ->
+        {:ok, %{data: data, page: page_number, page_size: page_size}}
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  @doc """
+  Returns a lazy `Stream` that yields all resources from a list endpoint,
+  fetching pages as needed.
+
+  The stream stops when a page returns fewer results than the page size,
+  indicating the last page has been reached.
+
+  ## Parameters
+
+  * `client` - Client map created with `Humaans.new/1`
+  * `list_fn` - A 2-arity list function, e.g. `&Humaans.People.list/2`
+  * `opts` - Options:
+    * `:page_size` - Number of results per page (default: #{@default_page_size})
+    * Any other options are forwarded as query parameters to `list_fn`
+
+  ## Examples
+
+      # Stream all people, 50 at a time
+      client
+      |> Humaans.Pagination.stream(&Humaans.People.list/2, page_size: 50)
+      |> Enum.each(fn person -> IO.puts(person.first_name) end)
+
+      # Stream compensations for a specific person
+      client
+      |> Humaans.Pagination.stream(
+        &Humaans.Compensations.list/2,
+        page_size: 100,
+        personId: "person-123"
+      )
+      |> Enum.to_list()
+
+  """
+  @spec stream(client :: map(), list_fn :: function(), opts :: keyword()) :: Enumerable.t()
+  def stream(client, list_fn, opts \\ []) do
+    page_size = Keyword.get(opts, :page_size, @default_page_size)
+
+    Stream.resource(
+      fn -> 1 end,
+      fn
+        :done ->
+          {:halt, :done}
+
+        page_number ->
+          case page(client, list_fn, page_number, opts) do
+            {:ok, %{data: []}} ->
+              {:halt, :done}
+
+            {:ok, %{data: data}} when length(data) < page_size ->
+              {data, :done}
+
+            {:ok, %{data: data}} ->
+              {data, page_number + 1}
+
+            {:error, _reason} ->
+              {:halt, :done}
+          end
+      end,
+      fn _state -> :ok end
+    )
+  end
+end

--- a/test/humaans/pagination_test.exs
+++ b/test/humaans/pagination_test.exs
@@ -1,0 +1,145 @@
+defmodule Humaans.PaginationTest do
+  use ExUnit.Case, async: false
+
+  @person_fixture %{
+    "id" => "IL3vneCYhIx0xrR6um2sy2nW",
+    "companyId" => "Gu6LHHK3S2lBNiRKLNbEmCDM",
+    "firstName" => "Kelsey",
+    "lastName" => "Wicks",
+    "email" => "kelsey@acme.com"
+  }
+
+  setup do
+    client = Humaans.new(access_token: "test-token", http_client: Humaans.MockHTTPClient)
+    {:ok, client: client}
+  end
+
+  describe "page/4" do
+    test "fetches page 1 with skip=0", %{client: client} do
+      Mox.expect(Humaans.MockHTTPClient, :request, fn _client, opts ->
+        assert opts[:params] == [limit: 10, skip: 0]
+        {:ok, %{status: 200, body: %{"data" => [@person_fixture]}}}
+      end)
+
+      assert {:ok, result} =
+               Humaans.Pagination.page(client, &Humaans.People.list/2, 1, page_size: 10)
+
+      assert result.page == 1
+      assert result.page_size == 10
+      assert length(result.data) == 1
+    end
+
+    test "fetches page 2 with correct skip offset", %{client: client} do
+      Mox.expect(Humaans.MockHTTPClient, :request, fn _client, opts ->
+        assert opts[:params] == [limit: 10, skip: 10]
+        {:ok, %{status: 200, body: %{"data" => []}}}
+      end)
+
+      assert {:ok, result} =
+               Humaans.Pagination.page(client, &Humaans.People.list/2, 2, page_size: 10)
+
+      assert result.page == 2
+      assert result.data == []
+    end
+
+    test "uses default page size when not specified", %{client: client} do
+      Mox.expect(Humaans.MockHTTPClient, :request, fn _client, opts ->
+        assert opts[:params] == [limit: 20, skip: 0]
+        {:ok, %{status: 200, body: %{"data" => []}}}
+      end)
+
+      assert {:ok, result} = Humaans.Pagination.page(client, &Humaans.People.list/2, 1)
+      assert result.page_size == 20
+    end
+
+    test "passes extra options as query params", %{client: client} do
+      Mox.expect(Humaans.MockHTTPClient, :request, fn _client, opts ->
+        assert opts[:params] == [personId: "abc", limit: 10, skip: 0]
+        {:ok, %{status: 200, body: %{"data" => []}}}
+      end)
+
+      assert {:ok, _result} =
+               Humaans.Pagination.page(client, &Humaans.People.list/2, 1,
+                 page_size: 10,
+                 personId: "abc"
+               )
+    end
+
+    test "returns error on API error", %{client: client} do
+      Mox.expect(Humaans.MockHTTPClient, :request, fn _client, _opts ->
+        {:ok, %{status: 401, body: %{"error" => "unauthorized"}}}
+      end)
+
+      assert {:error, _} = Humaans.Pagination.page(client, &Humaans.People.list/2, 1)
+    end
+  end
+
+  describe "stream/3" do
+    test "yields all items across multiple pages", %{client: client} do
+      # Page 1: full page of 2
+      Mox.expect(Humaans.MockHTTPClient, :request, fn _client, opts ->
+        assert opts[:params] == [limit: 2, skip: 0]
+        {:ok, %{status: 200, body: %{"data" => [@person_fixture, @person_fixture]}}}
+      end)
+
+      # Page 2: partial page (last page)
+      Mox.expect(Humaans.MockHTTPClient, :request, fn _client, opts ->
+        assert opts[:params] == [limit: 2, skip: 2]
+        {:ok, %{status: 200, body: %{"data" => [@person_fixture]}}}
+      end)
+
+      results =
+        client
+        |> Humaans.Pagination.stream(&Humaans.People.list/2, page_size: 2)
+        |> Enum.to_list()
+
+      assert length(results) == 3
+    end
+
+    test "stops at an empty page", %{client: client} do
+      Mox.expect(Humaans.MockHTTPClient, :request, fn _client, _opts ->
+        {:ok, %{status: 200, body: %{"data" => []}}}
+      end)
+
+      results =
+        client
+        |> Humaans.Pagination.stream(&Humaans.People.list/2, page_size: 10)
+        |> Enum.to_list()
+
+      assert results == []
+    end
+
+    test "stops after a full page followed by an empty page", %{client: client} do
+      Mox.expect(Humaans.MockHTTPClient, :request, fn _client, opts ->
+        assert opts[:params] == [limit: 1, skip: 0]
+        {:ok, %{status: 200, body: %{"data" => [@person_fixture]}}}
+      end)
+
+      Mox.expect(Humaans.MockHTTPClient, :request, fn _client, opts ->
+        assert opts[:params] == [limit: 1, skip: 1]
+        {:ok, %{status: 200, body: %{"data" => []}}}
+      end)
+
+      results =
+        client
+        |> Humaans.Pagination.stream(&Humaans.People.list/2, page_size: 1)
+        |> Enum.to_list()
+
+      assert length(results) == 1
+    end
+
+    test "is lazy and only fetches pages on demand", %{client: client} do
+      # Only one request should be made because we only take 1 item
+      Mox.expect(Humaans.MockHTTPClient, :request, fn _client, _opts ->
+        {:ok, %{status: 200, body: %{"data" => [@person_fixture, @person_fixture]}}}
+      end)
+
+      result =
+        client
+        |> Humaans.Pagination.stream(&Humaans.People.list/2, page_size: 2)
+        |> Enum.take(1)
+
+      assert length(result) == 1
+    end
+  end
+end


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Add `Humaans.Pagination` module with `page/4` and `stream/3` helpers
- `page/4` fetches a specific page (1-based), returning the data and page metadata
- `stream/3` returns a lazy `Stream` that fetches pages on demand, stopping automatically when the last page is reached (detected by a partial or empty page)
- Extra options beyond `:page_size` are forwarded as query parameters to the list function, enabling filtering alongside pagination
- Add `Humaans.pagination/0` accessor on the main module
- Document pagination in the `Humaans` module docstring

This is a non-breaking, purely additive change. Existing `list/2` functions on all resource modules are unchanged.

```elixir
# Stream all active people, 50 at a time
client
|> Humaans.Pagination.stream(&Humaans.People.list/2, page_size: 50)
|> Stream.filter(&(&1.status == :active))
|> Enum.to_list()

# Fetch page 3 of compensations
{:ok, result} = Humaans.Pagination.page(client, &Humaans.Compensations.list/2, 3, page_size: 20)
```