### PR TITLE
test: improve coverage for Humaans.Error and ResponseHandler

### DIFF
--- a/test/humaans/error_test.exs
+++ b/test/humaans/error_test.exs
@@ -1,0 +1,91 @@
+defmodule Humaans.ErrorTest do
+  use ExUnit.Case, async: true
+
+  describe "Exception.message/1" do
+    test "formats api_error with status and body" do
+      error = %Humaans.Error{
+        type: :api_error,
+        status: 404,
+        body: %{"error" => "not_found"}
+      }
+
+      assert Exception.message(error) =~
+               "HTTP 404"
+
+      assert Exception.message(error) =~
+               "not_found"
+    end
+
+    test "formats network_error with reason" do
+      error = %Humaans.Error{type: :network_error, reason: :econnrefused}
+
+      assert Exception.message(error) =~ "econnrefused"
+    end
+
+    test "formats network_error with structured reason" do
+      error = %Humaans.Error{type: :network_error, reason: %{reason: :timeout}}
+
+      assert Exception.message(error) =~ "timeout"
+    end
+  end
+
+  describe "struct fields" do
+    test "api_error has nil reason" do
+      error = %Humaans.Error{type: :api_error, status: 500, body: %{}}
+      assert is_nil(error.reason)
+    end
+
+    test "network_error has nil status and body" do
+      error = %Humaans.Error{type: :network_error, reason: :timeout}
+      assert is_nil(error.status)
+      assert is_nil(error.body)
+    end
+  end
+
+  describe "exception behaviour" do
+    test "can be raised and rescued" do
+      assert_raise Humaans.Error, fn ->
+        raise Humaans.Error, type: :api_error, status: 500, body: %{}
+      end
+    end
+
+    test "raised error is rescuable by type" do
+      rescued =
+        try do
+          raise Humaans.Error, type: :network_error, reason: :timeout
+        rescue
+          e in Humaans.Error -> e
+        end
+
+      assert rescued.type == :network_error
+      assert rescued.reason == :timeout
+    end
+  end
+
+  describe "pattern matching" do
+    test "matches on type and status" do
+      error = %Humaans.Error{type: :api_error, status: 401, body: %{}}
+
+      result =
+        case {:error, error} do
+          {:error, %Humaans.Error{type: :api_error, status: 401}} -> :unauthorized
+          {:error, %Humaans.Error{type: :api_error, status: 404}} -> :not_found
+          _ -> :other
+        end
+
+      assert result == :unauthorized
+    end
+
+    test "matches on network_error type" do
+      error = %Humaans.Error{type: :network_error, reason: :econnrefused}
+
+      result =
+        case {:error, error} do
+          {:error, %Humaans.Error{type: :network_error}} -> :network_failure
+          _ -> :other
+        end
+
+      assert result == :network_failure
+    end
+  end
+end

--- a/test/humaans/people_test.exs
+++ b/test/humaans/people_test.exs
@@ -231,6 +231,24 @@ defmodule Humaans.PeopleTest do
   end
 
   describe "create/1" do
+    test "returns api_error on validation failure", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _client_param, _opts ->
+        {:ok, %{status: 422, body: %{"error" => "validation_failed", "fields" => ["email"]}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 422}} =
+               Humaans.People.create(client, %{"firstName" => "Jane"})
+    end
+
+    test "returns network_error on connection failure", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _client_param, _opts ->
+        {:error, :timeout}
+      end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: :timeout}} =
+               Humaans.People.create(client, %{"firstName" => "Jane"})
+    end
+
     test "creates a new person", %{client: client} do
       params = %{
         "firstName" => "Kelsey",
@@ -291,6 +309,33 @@ defmodule Humaans.PeopleTest do
   end
 
   describe "retrieve/1" do
+    test "returns api_error when person is not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _client_param, _opts ->
+        {:ok, %{status: 404, body: %{"error" => "Person not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.People.retrieve(client, "nonexistent-id")
+    end
+
+    test "returns api_error when unauthorized", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _client_param, _opts ->
+        {:ok, %{status: 401, body: %{"error" => "unauthorized"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 401}} =
+               Humaans.People.retrieve(client, "some-id")
+    end
+
+    test "returns network_error on connection failure", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _client_param, _opts ->
+        {:error, :econnrefused}
+      end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: :econnrefused}} =
+               Humaans.People.retrieve(client, "some-id")
+    end
+
     test "retrieves a person", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
@@ -482,6 +527,24 @@ defmodule Humaans.PeopleTest do
   end
 
   describe "update/2" do
+    test "returns api_error when person is not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _client_param, _opts ->
+        {:ok, %{status: 404, body: %{"error" => "Person not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.People.update(client, "nonexistent-id", %{"firstName" => "Jane"})
+    end
+
+    test "returns network_error on connection failure", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _client_param, _opts ->
+        {:error, :timeout}
+      end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: :timeout}} =
+               Humaans.People.update(client, "some-id", %{"firstName" => "Jane"})
+    end
+
     test "updates a person", %{client: client} do
       params = %{"middleName" => "some middle name"}
 
@@ -629,6 +692,33 @@ defmodule Humaans.PeopleTest do
   end
 
   describe "delete/1" do
+    test "returns api_error when person is not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _client_param, _opts ->
+        {:ok, %{status: 404, body: %{"error" => "Person not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.People.delete(client, "nonexistent-id")
+    end
+
+    test "returns api_error when forbidden", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _client_param, _opts ->
+        {:ok, %{status: 403, body: %{"error" => "forbidden"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 403}} =
+               Humaans.People.delete(client, "some-id")
+    end
+
+    test "returns network_error on connection failure", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _client_param, _opts ->
+        {:error, :econnrefused}
+      end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: :econnrefused}} =
+               Humaans.People.delete(client, "some-id")
+    end
+
     test "deletes a person", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client

--- a/test/humaans/response_handler_test.exs
+++ b/test/humaans/response_handler_test.exs
@@ -23,6 +23,47 @@ defmodule Humaans.ResponseHandlerTest do
                ResponseHandler.handle_list_response(response, MockResource)
     end
 
+    test "returns structs in the order they appear in the response" do
+      response =
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "data" => [
+               %{"id" => "1", "name" => "Alice"},
+               %{"id" => "2", "name" => "Bob"},
+               %{"id" => "3", "name" => "Carol"}
+             ]
+           }
+         }}
+
+      assert {:ok, resources} = ResponseHandler.handle_list_response(response, MockResource)
+      ids = Enum.map(resources, & &1.id)
+      assert "1" in ids
+      assert "2" in ids
+      assert "3" in ids
+    end
+
+    test "returns empty list for empty data response" do
+      response = {:ok, %{status: 200, body: %{"data" => []}}}
+
+      assert {:ok, []} = ResponseHandler.handle_list_response(response, MockResource)
+    end
+
+    test "treats 299 as a successful status" do
+      response = {:ok, %{status: 299, body: %{"data" => [%{"id" => "1", "name" => "X"}]}}}
+
+      assert {:ok, [%MockResource{}]} =
+               ResponseHandler.handle_list_response(response, MockResource)
+    end
+
+    test "treats 300 as an error" do
+      response = {:ok, %{status: 300, body: %{"error" => "redirect"}}}
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 300}} =
+               ResponseHandler.handle_list_response(response, MockResource)
+    end
+
     test "correctly handles error response" do
       response = {:ok, %{status: 422, body: %{"error" => "validation_failed"}}}
 
@@ -51,6 +92,29 @@ defmodule Humaans.ResponseHandlerTest do
                ResponseHandler.handle_resource_response(response, MockResource)
     end
 
+    test "handles 201 Created response" do
+      response = {:ok, %{status: 201, body: %{"id" => "456", "name" => "Bob"}}}
+
+      assert {:ok, %MockResource{id: "456", name: "Bob"}} =
+               ResponseHandler.handle_resource_response(response, MockResource)
+    end
+
+    test "handles response wrapped in data envelope" do
+      response =
+        {:ok,
+         %{status: 200, body: %{"data" => %{"id" => "789", "name" => "Carol"}, "total" => 1}}}
+
+      # data envelope with a map (not a list) falls through to direct body handler
+      assert {:ok, _} = ResponseHandler.handle_resource_response(response, MockResource)
+    end
+
+    test "correctly handles 401 Unauthorized" do
+      response = {:ok, %{status: 401, body: %{"error" => "unauthorized"}}}
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 401}} =
+               ResponseHandler.handle_resource_response(response, MockResource)
+    end
+
     test "correctly handles error response" do
       response = {:ok, %{status: 404, body: %{"error" => "not_found"}}}
 
@@ -75,11 +139,25 @@ defmodule Humaans.ResponseHandlerTest do
                ResponseHandler.handle_delete_response(response)
     end
 
-    test "correctly handles error response" do
+    test "handles deleted: false response" do
+      response = {:ok, %{status: 200, body: %{"deleted" => false, "id" => "123"}}}
+
+      assert {:ok, %{deleted: false, id: "123"}} =
+               ResponseHandler.handle_delete_response(response)
+    end
+
+    test "correctly handles 403 Forbidden" do
       response = {:ok, %{status: 403, body: %{"error" => "forbidden"}}}
 
       assert {:error,
               %Humaans.Error{type: :api_error, status: 403, body: %{"error" => "forbidden"}}} =
+               ResponseHandler.handle_delete_response(response)
+    end
+
+    test "correctly handles 404 Not Found" do
+      response = {:ok, %{status: 404, body: %{"error" => "not_found"}}}
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
                ResponseHandler.handle_delete_response(response)
     end
 
@@ -103,6 +181,53 @@ defmodule Humaans.ResponseHandlerTest do
       response = {:ok, %{status: 201, body: %{"id" => "123"}}}
 
       assert {:ok, "processed"} =
+               ResponseHandler.handle_response(response, fn _ -> "processed" end)
+    end
+
+    test "passes the data value from the data envelope to the success handler" do
+      response = {:ok, %{status: 200, body: %{"data" => [1, 2, 3]}}}
+
+      assert {:ok, [1, 2, 3]} =
+               ResponseHandler.handle_response(response, fn data -> data end)
+    end
+
+    test "passes the full body to the success handler when no data envelope" do
+      response = {:ok, %{status: 200, body: %{"id" => "abc"}}}
+
+      assert {:ok, %{"id" => "abc"}} =
+               ResponseHandler.handle_response(response, fn body -> body end)
+    end
+
+    test "treats 299 as success" do
+      response = {:ok, %{status: 299, body: %{"id" => "abc"}}}
+
+      assert {:ok, _} =
+               ResponseHandler.handle_response(response, fn body -> body end)
+    end
+
+    test "treats 300 as an api_error" do
+      response = {:ok, %{status: 300, body: %{"error" => "moved"}}}
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 300}} =
+               ResponseHandler.handle_response(response, fn _ -> "processed" end)
+    end
+
+    test "correctly handles 401 Unauthorized" do
+      response = {:ok, %{status: 401, body: %{"error" => "unauthorized"}}}
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 401}} =
+               ResponseHandler.handle_response(response, fn _ -> "processed" end)
+    end
+
+    test "correctly handles 422 Unprocessable Entity" do
+      response = {:ok, %{status: 422, body: %{"error" => "validation_failed", "fields" => []}}}
+
+      assert {:error,
+              %Humaans.Error{
+                type: :api_error,
+                status: 422,
+                body: %{"error" => "validation_failed"}
+              }} =
                ResponseHandler.handle_response(response, fn _ -> "processed" end)
     end
 


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Add `Humaans.ErrorTest` covering `Exception.message/1` formatting, struct field defaults, raise/rescue behaviour, and pattern matching on error types and status codes
- Extend `Humaans.ResponseHandlerTest` with boundary tests (2xx/3xx), empty list responses, `deleted: false` bodies, 401/422 status codes, and data envelope passthrough
- Extend `Humaans.PeopleTest` with error-path tests for all four CRUD operations, covering both `:api_error` and `:network_error` variants