### PR TITLE
chore: configure release-please to update README version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,15 @@ An Elixir client for the [Humaans API][humaans-api-docs].
 The package can be installed by adding `humaans` to your list of dependencies in
 `mix.exs`:
 
+<!-- x-release-please-start-version -->
 ```elixir
 def deps do
   [
-    {:humaans, "~> 0.4"}
+    {:humaans, "~> 0.5.0"}
   ]
 end
 ```
+<!-- x-release-please-end -->
 
 ## Usage
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,10 @@
 {
-  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "elixir",
   "packages": {
-    ".": {}
+    ".": {
+      "release-type": "elixir",
+      "extra-files": [
+        "README.md"
+      ]
+    }
   }
 }


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Move `release-type` inside the package object and add `extra-files: ["README.md"]` to `release-please-config.json` so release-please's generic updater tracks the version in the installation snippet
- Annotate the `deps` code block in `README.md` with `x-release-please-start-version` / `x-release-please-end` HTML comment markers and pin the version to `~> 0.5.0` (three-component form required by the generic updater's semver regex)