### PR TITLE
test: improve coverage to 100%

### DIFF
--- a/test/humaans/http_client/req_test.exs
+++ b/test/humaans/http_client/req_test.exs
@@ -56,6 +56,15 @@ defmodule Humaans.HTTPClient.ReqTest do
       assert result == {:ok, response}
     end
 
+    test "configures PATCH requests without a body", %{client: client} do
+      response_body = %{"id" => "123"}
+      {response, request_opts} = setup_test(:patch, "/people/123", response_body)
+
+      result = HumaansReq.request(client, request_opts)
+
+      assert result == {:ok, response}
+    end
+
     test "configures DELETE requests correctly", %{client: client} do
       response_body = %{"id" => "123", "deleted" => true}
       {response, request_opts} = setup_test(:delete, "/people/123", response_body)

--- a/test/humaans/pagination_test.exs
+++ b/test/humaans/pagination_test.exs
@@ -128,6 +128,19 @@ defmodule Humaans.PaginationTest do
       assert length(results) == 1
     end
 
+    test "halts silently on API error", %{client: client} do
+      Mox.expect(Humaans.MockHTTPClient, :request, fn _client, _opts ->
+        {:ok, %{status: 401, body: %{"error" => "unauthorized"}}}
+      end)
+
+      results =
+        client
+        |> Humaans.Pagination.stream(&Humaans.People.list/2, page_size: 10)
+        |> Enum.to_list()
+
+      assert results == []
+    end
+
     test "is lazy and only fetches pages on demand", %{client: client} do
       # Only one request should be made because we only take 1 item
       Mox.expect(Humaans.MockHTTPClient, :request, fn _client, _opts ->

--- a/test/humaans/resource_test.exs
+++ b/test/humaans/resource_test.exs
@@ -35,6 +35,29 @@ defmodule Humaans.ResourceTest do
     def list(_client, _params), do: {:ok, :overridden}
   end
 
+  # Resource using binary string doc_params — exercises extract_string(s when is_binary)
+  # and the if cp/up doc string branches.
+  defmodule DocParamsResource do
+    use Humaans.Resource,
+      path: "/doc-params-items",
+      struct: Humaans.ResourceTest.TestItem,
+      doc_params: [
+        create: "%{name: \"example\"}",
+        update: "%{name: \"updated\"}"
+      ]
+  end
+
+  # Resource using ~s sigil doc_params — exercises extract_string({:sigil_s, ...}).
+  defmodule SigilDocParamsResource do
+    use Humaans.Resource,
+      path: "/sigil-doc-params-items",
+      struct: Humaans.ResourceTest.TestItem,
+      doc_params: [
+        create: ~s(%{name: "example"}),
+        update: ~s(%{name: "updated"})
+      ]
+  end
+
   setup :verify_on_exit!
 
   setup_all do
@@ -186,6 +209,20 @@ defmodule Humaans.ResourceTest do
   describe "defoverridable" do
     test "generated functions can be overridden", %{client: client} do
       assert {:ok, :overridden} = OverridingResource.list(client, %{})
+    end
+  end
+
+  describe "doc_params option" do
+    test "generates CRUD functions with binary string doc_params" do
+      assert function_exported?(DocParamsResource, :list, 2)
+      assert function_exported?(DocParamsResource, :create, 2)
+      assert function_exported?(DocParamsResource, :update, 3)
+    end
+
+    test "generates CRUD functions with sigil doc_params" do
+      assert function_exported?(SigilDocParamsResource, :list, 2)
+      assert function_exported?(SigilDocParamsResource, :create, 2)
+      assert function_exported?(SigilDocParamsResource, :update, 3)
     end
   end
 end

--- a/test/humaans_test.exs
+++ b/test/humaans_test.exs
@@ -87,4 +87,8 @@ defmodule HumaansTest do
   test "timesheet_submissions/0 returns the TimesheetSubmissions module" do
     assert Humaans.timesheet_submissions() == Humaans.TimesheetSubmissions
   end
+
+  test "pagination/0 returns the Pagination module" do
+    assert Humaans.pagination() == Humaans.Pagination
+  end
 end


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Add test for `Humaans.pagination/0` accessor (was the one uncovered line in `humaans.ex`)
- Add test for `HTTPClient.Req` when a PATCH/POST is sent without a body (covers the `nil` branch in the body-handling case)
- Add test for `Pagination.stream/3` halting silently on an API error mid-stream
- Add `DocParamsResource` and `SigilDocParamsResource` test modules to `resource_test.exs` to cover the `doc_params` branches in the `Resource` macro (binary string and `~s` sigil variants of `extract_string/1`, plus the `if cp do`/`if up do` doc string branches)

Overall coverage: 89.3% → 100%