### PR TITLE
fix(pagination): use $-prefixed limit/skip params

### DIFF
--- a/lib/humaans/client.ex
+++ b/lib/humaans/client.ex
@@ -94,7 +94,7 @@ defmodule Humaans.Client do
 
   * `client` - The Humaans client struct
   * `path` - API endpoint path (e.g., "/people")
-  * `params` - Query parameters as keyword list (e.g., [limit: 10, skip: 20])
+  * `params` - Query parameters as keyword list (e.g., ["$limit": 10, "$skip": 20])
 
   ## Returns
 

--- a/lib/humaans/pagination.ex
+++ b/lib/humaans/pagination.ex
@@ -2,7 +2,7 @@ defmodule Humaans.Pagination do
   @moduledoc """
   Helpers for paginating through Humaans API list endpoints.
 
-  The Humaans API uses offset-based pagination via `limit` and `skip`
+  The Humaans API uses offset-based pagination via `$limit` and `$skip`
   parameters. All list endpoints support these parameters.
 
   ## Page-by-page iteration
@@ -78,7 +78,7 @@ defmodule Humaans.Pagination do
     extra_params = Keyword.drop(opts, [:page_size])
 
     skip = (page_number - 1) * page_size
-    params = Keyword.merge(extra_params, limit: page_size, skip: skip)
+    params = Keyword.merge(extra_params, "$limit": page_size, "$skip": skip)
 
     case list_fn.(client, params) do
       {:ok, data} when is_list(data) ->

--- a/test/humaans/pagination_test.exs
+++ b/test/humaans/pagination_test.exs
@@ -17,7 +17,7 @@ defmodule Humaans.PaginationTest do
   describe "page/4" do
     test "fetches page 1 with skip=0", %{client: client} do
       Mox.expect(Humaans.MockHTTPClient, :request, fn _client, opts ->
-        assert opts[:params] == [limit: 10, skip: 0]
+        assert opts[:params] == ["$limit": 10, "$skip": 0]
         {:ok, %{status: 200, body: %{"data" => [@person_fixture]}}}
       end)
 
@@ -31,7 +31,7 @@ defmodule Humaans.PaginationTest do
 
     test "fetches page 2 with correct skip offset", %{client: client} do
       Mox.expect(Humaans.MockHTTPClient, :request, fn _client, opts ->
-        assert opts[:params] == [limit: 10, skip: 10]
+        assert opts[:params] == ["$limit": 10, "$skip": 10]
         {:ok, %{status: 200, body: %{"data" => []}}}
       end)
 
@@ -44,7 +44,7 @@ defmodule Humaans.PaginationTest do
 
     test "uses default page size when not specified", %{client: client} do
       Mox.expect(Humaans.MockHTTPClient, :request, fn _client, opts ->
-        assert opts[:params] == [limit: 20, skip: 0]
+        assert opts[:params] == ["$limit": 20, "$skip": 0]
         {:ok, %{status: 200, body: %{"data" => []}}}
       end)
 
@@ -54,7 +54,7 @@ defmodule Humaans.PaginationTest do
 
     test "passes extra options as query params", %{client: client} do
       Mox.expect(Humaans.MockHTTPClient, :request, fn _client, opts ->
-        assert opts[:params] == [personId: "abc", limit: 10, skip: 0]
+        assert opts[:params] == [personId: "abc", "$limit": 10, "$skip": 0]
         {:ok, %{status: 200, body: %{"data" => []}}}
       end)
 
@@ -78,13 +78,13 @@ defmodule Humaans.PaginationTest do
     test "yields all items across multiple pages", %{client: client} do
       # Page 1: full page of 2
       Mox.expect(Humaans.MockHTTPClient, :request, fn _client, opts ->
-        assert opts[:params] == [limit: 2, skip: 0]
+        assert opts[:params] == ["$limit": 2, "$skip": 0]
         {:ok, %{status: 200, body: %{"data" => [@person_fixture, @person_fixture]}}}
       end)
 
       # Page 2: partial page (last page)
       Mox.expect(Humaans.MockHTTPClient, :request, fn _client, opts ->
-        assert opts[:params] == [limit: 2, skip: 2]
+        assert opts[:params] == ["$limit": 2, "$skip": 2]
         {:ok, %{status: 200, body: %{"data" => [@person_fixture]}}}
       end)
 
@@ -111,12 +111,12 @@ defmodule Humaans.PaginationTest do
 
     test "stops after a full page followed by an empty page", %{client: client} do
       Mox.expect(Humaans.MockHTTPClient, :request, fn _client, opts ->
-        assert opts[:params] == [limit: 1, skip: 0]
+        assert opts[:params] == ["$limit": 1, "$skip": 0]
         {:ok, %{status: 200, body: %{"data" => [@person_fixture]}}}
       end)
 
       Mox.expect(Humaans.MockHTTPClient, :request, fn _client, opts ->
-        assert opts[:params] == [limit: 1, skip: 1]
+        assert opts[:params] == ["$limit": 1, "$skip": 1]
         {:ok, %{status: 200, body: %{"data" => []}}}
       end)
 


### PR DESCRIPTION
:tipping_hand_person: These changes switch `Humaans.Pagination` to send the documented `$limit` and `$skip` query parameters instead of unprefixed `limit`/`skip` aliases.

## Summary

- Send `$limit` and `$skip` query params per the documented Humaans API contract.
- Previously the library sent unprefixed `limit`/`skip`, which the API currently accepts as an undocumented alias.
- Pagination internals only — `Humaans.Pagination.page/4` and `stream/3` continue to take `:page_size` from callers.

## Test plan

- [x] `mix test` passes
- [x] `mix credo --strict` clean
- [x] Smoke test against a real Humaans tenant (`Humaans.Pagination.stream(client, &Humaans.People.list/2)` returns multiple pages)