### PR TITLE
perf(pagination): default page size to 100

### DIFF
--- a/lib/humaans/pagination.ex
+++ b/lib/humaans/pagination.ex
@@ -40,7 +40,7 @@ defmodule Humaans.Pagination do
 
   """
 
-  @default_page_size 20
+  @default_page_size 100
 
   @type page_result(resource) :: %{
           data: [resource],

--- a/test/humaans/pagination_test.exs
+++ b/test/humaans/pagination_test.exs
@@ -141,6 +141,20 @@ defmodule Humaans.PaginationTest do
       assert results == []
     end
 
+    test "uses default page size when not specified", %{client: client} do
+      Mox.expect(Humaans.MockHTTPClient, :request, fn _client, opts ->
+        assert opts[:params] == ["$limit": 100, "$skip": 0]
+        {:ok, %{status: 200, body: %{"data" => []}}}
+      end)
+
+      results =
+        client
+        |> Humaans.Pagination.stream(&Humaans.People.list/2)
+        |> Enum.to_list()
+
+      assert results == []
+    end
+
     test "is lazy and only fetches pages on demand", %{client: client} do
       # Only one request should be made because we only take 1 item
       Mox.expect(Humaans.MockHTTPClient, :request, fn _client, _opts ->

--- a/test/humaans/pagination_test.exs
+++ b/test/humaans/pagination_test.exs
@@ -44,12 +44,12 @@ defmodule Humaans.PaginationTest do
 
     test "uses default page size when not specified", %{client: client} do
       Mox.expect(Humaans.MockHTTPClient, :request, fn _client, opts ->
-        assert opts[:params] == ["$limit": 20, "$skip": 0]
+        assert opts[:params] == ["$limit": 100, "$skip": 0]
         {:ok, %{status: 200, body: %{"data" => []}}}
       end)
 
       assert {:ok, result} = Humaans.Pagination.page(client, &Humaans.People.list/2, 1)
-      assert result.page_size == 20
+      assert result.page_size == 100
     end
 
     test "passes extra options as query params", %{client: client} do


### PR DESCRIPTION
:tipping_hand_person: These changes raise the default `Humaans.Pagination` page size from 20 to 100, matching the Humaans API's own default and reducing round-trips for bulk reads by 5x.

## Summary

- Bump `Humaans.Pagination` default `page_size` from 20 to 100 (matches Humaans API default; max is 250).
- 5x fewer round-trips for `stream/3` and `page/4` callers that don't override `:page_size`.

## Tradeoffs

- Slightly higher memory per page. Callers wanting smaller batches can still pass `page_size: 20`.

## Test plan

- [x] `mix test` passes (existing default-size assertions updated)
- [x] Smoke test against a real tenant — confirm a single page returns up to 100 records