### PR TITLE
feat(error): extract structured Humaans API error fields

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ Humaans.new/1
 
 **Resource structs** — Live in `lib/humaans/resources/`. Use `ExConstructor` for automatic camelCase→snake_case JSON mapping. `Humaans.Response` holds raw HTTP responses (`status`, `headers`, `body`).
 
-**Response handling** — `Humaans.ResponseHandler` unwraps `{"data": [...]}` envelopes and converts payloads to typed structs.
+**Response handling** — `Humaans.ResponseHandler` unwraps `{"data": [...]}` envelopes and converts payloads to typed structs. On non-2xx responses it builds a `Humaans.Error` via `Humaans.Error.from_api_response/2`, which extracts the API's structured error fields (`code`, `name`, `message`, `issues`) onto the struct while retaining the raw `body`.
 
 ### Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ Humaans.new/1
 
 **Resource structs** — Live in `lib/humaans/resources/`. Use `ExConstructor` for automatic camelCase→snake_case JSON mapping. `Humaans.Response` holds raw HTTP responses (`status`, `headers`, `body`).
 
-**Response handling** — `Humaans.ResponseHandler` unwraps `{"data": [...]}` envelopes and converts payloads to typed structs. On non-2xx responses it builds a `Humaans.Error` via `Humaans.Error.from_api_response/2`, which extracts the API's structured error fields (`code`, `name`, `message`, `issues`) onto the struct while retaining the raw `body`.
+**Response handling** — `Humaans.ResponseHandler` unwraps `{"data": [...]}` envelopes and converts payloads to typed structs. On non-2xx responses it builds a `Humaans.Error` via `Humaans.Error.from_api_response/2`, which extracts the API's structured error fields onto the struct as `code`, `name`, `api_message` (from the API's `message`), and `issues`, while retaining the raw `body`.
 
 ### Testing
 

--- a/lib/humaans/error.ex
+++ b/lib/humaans/error.ex
@@ -6,10 +6,27 @@ defmodule Humaans.Error do
 
   * `:api_error` - The API returned a non-2xx HTTP status code. The `status`
     field contains the HTTP status code and `body` contains the parsed response
-    body.
+    body. The Humaans API's structured error envelope (`code`, `name`,
+    `message`, `issues`) is also extracted onto top-level fields when present.
   * `:network_error` - A transport-level error occurred before a response was
     received (e.g. connection refused, DNS failure). The `reason` field contains
     the underlying error.
+
+  ## Structured API error fields
+
+  When the API returns a structured error body, the following fields are
+  populated:
+
+  * `code` - Short error code, e.g. `"ValidationError"`, `"NotFound"`.
+  * `name` - Human-readable error name.
+  * `api_message` - The API's error message string. (Named to avoid shadowing
+    the `Exception.message/1` callback, which returns a formatted display
+    string.)
+  * `issues` - List of field-level validation errors (each typically a map with
+    `path` and `message` keys). `nil` if not present.
+
+  The raw `body` is always retained for forward-compatibility with undocumented
+  fields.
 
   ## Examples
 
@@ -19,6 +36,10 @@ defmodule Humaans.Error do
 
         {:error, %Humaans.Error{type: :api_error, status: 404}} ->
           :not_found
+
+        {:error, %Humaans.Error{type: :api_error, status: 422, issues: issues}}
+        when is_list(issues) ->
+          {:invalid, issues}
 
         {:error, %Humaans.Error{type: :api_error, status: 401}} ->
           :unauthorized
@@ -31,21 +52,67 @@ defmodule Humaans.Error do
 
   @type error_type :: :api_error | :network_error
 
+  @type issue :: %{optional(String.t()) => any()}
+
   @type t :: %__MODULE__{
           type: error_type(),
           status: non_neg_integer() | nil,
           body: map() | nil,
-          reason: any()
+          reason: any(),
+          code: String.t() | nil,
+          name: String.t() | nil,
+          api_message: String.t() | nil,
+          issues: [issue()] | nil
         }
 
-  defexception [:type, :status, :body, :reason]
+  defexception [:type, :status, :body, :reason, :code, :name, :api_message, :issues]
 
   @impl Exception
+  def message(%__MODULE__{type: :api_error, status: status, api_message: msg})
+      when is_binary(msg) do
+    "Humaans API error: HTTP #{status} - #{msg}"
+  end
+
   def message(%__MODULE__{type: :api_error, status: status, body: body}) do
     "Humaans API error: HTTP #{status} - #{inspect(body)}"
   end
 
   def message(%__MODULE__{type: :network_error, reason: reason}) do
     "Humaans network error: #{inspect(reason)}"
+  end
+
+  @doc """
+  Builds an `:api_error` from an HTTP status and response body, extracting
+  the API's structured error fields when present.
+  """
+  @spec from_api_response(non_neg_integer(), any()) :: t()
+  def from_api_response(status, body) when is_map(body) do
+    %__MODULE__{
+      type: :api_error,
+      status: status,
+      body: body,
+      code: extract_string(body, "code"),
+      name: extract_string(body, "name"),
+      api_message: extract_string(body, "message"),
+      issues: extract_issues(body)
+    }
+  end
+
+  def from_api_response(status, body) do
+    %__MODULE__{type: :api_error, status: status, body: body}
+  end
+
+  defp extract_string(body, key) do
+    case Map.get(body, key) do
+      v when is_binary(v) -> v
+      _ -> nil
+    end
+  end
+
+  defp extract_issues(body) do
+    case Map.get(body, "issues") do
+      v when is_list(v) -> v
+      _ -> nil
+    end
   end
 end

--- a/lib/humaans/error.ex
+++ b/lib/humaans/error.ex
@@ -57,7 +57,7 @@ defmodule Humaans.Error do
   @type t :: %__MODULE__{
           type: error_type(),
           status: non_neg_integer() | nil,
-          body: map() | nil,
+          body: any(),
           reason: any(),
           code: String.t() | nil,
           name: String.t() | nil,
@@ -111,8 +111,11 @@ defmodule Humaans.Error do
 
   defp extract_issues(body) do
     case Map.get(body, "issues") do
-      v when is_list(v) -> v
-      _ -> nil
+      v when is_list(v) ->
+        if Enum.all?(v, &is_map/1), do: v, else: nil
+
+      _ ->
+        nil
     end
   end
 end

--- a/lib/humaans/response_handler.ex
+++ b/lib/humaans/response_handler.ex
@@ -100,7 +100,7 @@ defmodule Humaans.ResponseHandler do
         {:ok, success_handler.(body)}
 
       {:ok, %{status: status, body: body}} ->
-        {:error, %Humaans.Error{type: :api_error, status: status, body: body}}
+        {:error, Humaans.Error.from_api_response(status, body)}
 
       {:error, reason} ->
         {:error, %Humaans.Error{type: :network_error, reason: reason}}

--- a/test/humaans/error_test.exs
+++ b/test/humaans/error_test.exs
@@ -16,6 +16,17 @@ defmodule Humaans.ErrorTest do
                "not_found"
     end
 
+    test "formats api_error with api_message when present" do
+      error = %Humaans.Error{
+        type: :api_error,
+        status: 422,
+        api_message: "Validation failed",
+        body: %{"message" => "Validation failed"}
+      }
+
+      assert Exception.message(error) == "Humaans API error: HTTP 422 - Validation failed"
+    end
+
     test "formats network_error with reason" do
       error = %Humaans.Error{type: :network_error, reason: :econnrefused}
 
@@ -26,6 +37,65 @@ defmodule Humaans.ErrorTest do
       error = %Humaans.Error{type: :network_error, reason: %{reason: :timeout}}
 
       assert Exception.message(error) =~ "timeout"
+    end
+  end
+
+  describe "from_api_response/2" do
+    test "extracts code, name, message, and issues from structured body" do
+      body = %{
+        "id" => "req-1",
+        "code" => "ValidationError",
+        "name" => "BadRequest",
+        "message" => "email is required",
+        "issues" => [%{"path" => "email", "message" => "must be present"}]
+      }
+
+      error = Humaans.Error.from_api_response(422, body)
+
+      assert error.type == :api_error
+      assert error.status == 422
+      assert error.code == "ValidationError"
+      assert error.name == "BadRequest"
+      assert error.api_message == "email is required"
+      assert error.issues == [%{"path" => "email", "message" => "must be present"}]
+      assert error.body == body
+    end
+
+    test "leaves structured fields nil when body lacks them" do
+      body = %{"error" => "something"}
+      error = Humaans.Error.from_api_response(500, body)
+
+      assert error.type == :api_error
+      assert error.status == 500
+      assert error.code == nil
+      assert error.name == nil
+      assert error.api_message == nil
+      assert error.issues == nil
+      assert error.body == body
+    end
+
+    test "ignores non-string code/name/message values" do
+      body = %{"code" => 42, "name" => nil, "message" => %{}}
+      error = Humaans.Error.from_api_response(400, body)
+
+      assert error.code == nil
+      assert error.name == nil
+      assert error.api_message == nil
+    end
+
+    test "ignores non-list issues values" do
+      body = %{"issues" => "not a list"}
+      error = Humaans.Error.from_api_response(400, body)
+      assert error.issues == nil
+    end
+
+    test "handles non-map body" do
+      error = Humaans.Error.from_api_response(502, "Bad Gateway")
+
+      assert error.type == :api_error
+      assert error.status == 502
+      assert error.body == "Bad Gateway"
+      assert error.code == nil
     end
   end
 

--- a/test/humaans/response_handler_test.exs
+++ b/test/humaans/response_handler_test.exs
@@ -245,5 +245,27 @@ defmodule Humaans.ResponseHandlerTest do
       assert {:error, %Humaans.Error{type: :network_error, reason: "connection_error"}} =
                ResponseHandler.handle_response(response, fn _ -> "processed" end)
     end
+
+    test "extracts structured error fields from a 422 body" do
+      body = %{
+        "id" => "req-1",
+        "code" => "ValidationError",
+        "name" => "BadRequest",
+        "message" => "email is required",
+        "issues" => [%{"path" => "email", "message" => "must be present"}]
+      }
+
+      response = {:ok, %{status: 422, body: body}}
+
+      assert {:error,
+              %Humaans.Error{
+                type: :api_error,
+                status: 422,
+                code: "ValidationError",
+                name: "BadRequest",
+                api_message: "email is required",
+                issues: [%{"path" => "email"}]
+              }} = ResponseHandler.handle_response(response, fn _ -> :ok end)
+    end
   end
 end


### PR DESCRIPTION
:tipping_hand_person: These changes parse the Humaans API's structured error envelope onto top-level fields of `Humaans.Error` so callers no longer have to dig into the raw body to read `code`, `name`, `message`, or per-field validation `issues`.

## Summary

- Add `code`, `name`, `api_message`, `issues` fields to `Humaans.Error`, populated from the Humaans error envelope (`{id, code, name, message, issues[]}`).
- Add `Humaans.Error.from_api_response/2` builder, called from `Humaans.ResponseHandler`.
- Field is named `api_message` to avoid shadowing `Exception.message/1`.
- Raw `body` is retained for forward-compat with undocumented fields.
- Existing pattern matches on `type`/`status`/`body`/`reason` continue to work.

## Test plan

- [x] `mix test` passes (175 → 181 tests; new coverage for structured-error parsing and `Exception.message/1` formatting)
- [x] `mix credo --strict` clean
- [x] Trigger a real 422 in a smoke environment and confirm `error.issues` is a list of field-level maps