### PR TITLE
feat(http_client): pass-through req_options on Humaans.new/1

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,22 @@ client = Humaans.new(access_token: "YOUR_ACCESS_TOKEN")
 
 This approach allows you to create multiple clients with different access tokens and use them independently.
 
+### Tuning the HTTP client
+
+Pass `:req_options` to `Humaans.new/1` to customise the underlying [Req][req] client (timeouts, retries, plugins, etc.):
+
+```elixir
+client =
+  Humaans.new(
+    access_token: "YOUR_ACCESS_TOKEN",
+    req_options: [connect_options: [timeout: 30_000], retry: :transient]
+  )
+```
+
+For deeper customisation, implement `Humaans.HTTPClient.Behaviour` and pass the module via `:http_client`.
+
+[req]: https://hexdocs.pm/req/
+
 ### Module access helpers
 
 The library provides convenience functions to access the different resource modules:

--- a/lib/humaans.ex
+++ b/lib/humaans.ex
@@ -24,6 +24,9 @@ defmodule Humaans do
   * `:access_token` - Your Humaans API access token (required)
   * `:base_url` - The base URL for API requests (defaults to "https://app.humaans.io/api")
   * `:http_client` - The HTTP client module to use (defaults to `Humaans.HTTPClient.Req`)
+  * `:req_options` - Keyword list merged into the default `Req` client config
+    (e.g. `[connect_options: [timeout: 30_000], retry: :transient]`). Has no
+    effect when `:http_client` is overridden.
 
   ## Examples
 
@@ -40,6 +43,12 @@ defmodule Humaans do
       client = Humaans.new(
         access_token: "some-access-token",
         http_client: MyCustomHTTPClient
+      )
+
+      # Tune timeouts and retries on the default Req client
+      client = Humaans.new(
+        access_token: "some-access-token",
+        req_options: [connect_options: [timeout: 30_000], retry: :transient]
       )
 
       # Make API calls
@@ -78,11 +87,12 @@ defmodule Humaans do
   @type t :: %__MODULE__{
           access_token: String.t(),
           base_url: String.t(),
-          http_client: module()
+          http_client: module(),
+          req_options: keyword()
         }
 
   @enforce_keys [:access_token, :base_url, :http_client]
-  defstruct [:access_token, :base_url, :http_client]
+  defstruct [:access_token, :base_url, :http_client, req_options: []]
 
   @base_url "https://app.humaans.io/api"
 
@@ -92,6 +102,9 @@ defmodule Humaans do
   ## Options
     * `:access_token` - The access token to use for authentication (required)
     * `:base_url` - The base URL for API requests (defaults to #{@base_url})
+    * `:http_client` - HTTP client module (defaults to `Humaans.HTTPClient.Req`)
+    * `:req_options` - Keyword list merged into the default `Req` client
+      config. Ignored when `:http_client` is overridden.
 
   ## Examples
       iex> client = Humaans.new(access_token: "some-access-token")
@@ -103,11 +116,13 @@ defmodule Humaans do
     access_token = Keyword.fetch!(opts, :access_token)
     base_url = Keyword.get(opts, :base_url, @base_url)
     http_client = Keyword.get(opts, :http_client, Humaans.HTTPClient.Req)
+    req_options = Keyword.get(opts, :req_options, [])
 
     struct!(__MODULE__,
       access_token: access_token,
       base_url: base_url,
-      http_client: http_client
+      http_client: http_client,
+      req_options: req_options
     )
   end
 

--- a/lib/humaans.ex
+++ b/lib/humaans.ex
@@ -116,7 +116,7 @@ defmodule Humaans do
     access_token = Keyword.fetch!(opts, :access_token)
     base_url = Keyword.get(opts, :base_url, @base_url)
     http_client = Keyword.get(opts, :http_client, Humaans.HTTPClient.Req)
-    req_options = Keyword.get(opts, :req_options, [])
+    req_options = validate_req_options(Keyword.get(opts, :req_options, []))
 
     struct!(__MODULE__,
       access_token: access_token,
@@ -124,6 +124,22 @@ defmodule Humaans do
       http_client: http_client,
       req_options: req_options
     )
+  end
+
+  defp validate_req_options(nil), do: []
+
+  defp validate_req_options(opts) when is_list(opts) do
+    if Keyword.keyword?(opts) do
+      opts
+    else
+      raise ArgumentError,
+            ":req_options must be a keyword list, got: #{inspect(opts)}"
+    end
+  end
+
+  defp validate_req_options(other) do
+    raise ArgumentError,
+          ":req_options must be a keyword list, got: #{inspect(other)}"
   end
 
   @doc """

--- a/lib/humaans/http_client/req.ex
+++ b/lib/humaans/http_client/req.ex
@@ -7,9 +7,17 @@ defmodule Humaans.HTTPClient.Req do
 
   ## Customization
 
-  If you need to customize the Req client behavior (such as adding middleware,
-  changing timeouts, etc.), you can implement your own client module that builds
-  on this implementation while adding your specific modifications.
+  For most tweaks (timeouts, retries, plugins), pass `:req_options` directly
+  to `Humaans.new/1`. They are merged into the Req client config:
+
+      Humaans.new(
+        access_token: "...",
+        req_options: [connect_options: [timeout: 30_000], retry: :transient]
+      )
+
+  If you need to wrap or replace the entire request pipeline, implement your
+  own module satisfying `Humaans.HTTPClient.Behaviour` and pass it via
+  `:http_client`:
 
   ```elixir
   defmodule MyCustomReqClient do
@@ -17,11 +25,7 @@ defmodule Humaans.HTTPClient.Req do
 
     @impl true
     def request(client, opts) do
-      Req.new(
-        base_url: client.base_url,
-        auth: {:bearer, client.access_token},
-        connect_options: [timeout: 30_000] # Custom timeout
-      )
+      Req.new(base_url: client.base_url, auth: {:bearer, client.access_token})
       |> Req.merge(opts)
       # Add custom Req plugins or middleware here
       |> Req.request()
@@ -66,10 +70,12 @@ defmodule Humaans.HTTPClient.Req do
           opts
       end
 
-    Req.new(
-      base_url: client.base_url,
-      auth: {:bearer, client.access_token}
-    )
+    base =
+      [base_url: client.base_url, auth: {:bearer, client.access_token}]
+      |> Keyword.merge(Map.get(client, :req_options, []))
+
+    base
+    |> Req.new()
     |> Req.merge(opts)
     |> Req.request()
   end

--- a/lib/humaans/http_client/req.ex
+++ b/lib/humaans/http_client/req.ex
@@ -70,9 +70,15 @@ defmodule Humaans.HTTPClient.Req do
           opts
       end
 
+    req_options =
+      (Map.get(client, :req_options) || [])
+      |> Keyword.drop([:base_url, :auth])
+
     base =
-      [base_url: client.base_url, auth: {:bearer, client.access_token}]
-      |> Keyword.merge(Map.get(client, :req_options, []))
+      Keyword.merge(req_options,
+        base_url: client.base_url,
+        auth: {:bearer, client.access_token}
+      )
 
     base
     |> Req.new()

--- a/test/humaans/http_client/req_test.exs
+++ b/test/humaans/http_client/req_test.exs
@@ -121,6 +121,58 @@ defmodule Humaans.HTTPClient.ReqTest do
       assert options[:connect_options] == [timeout: 7_777]
       assert options[:retry] == false
     end
+
+    test "tolerates a struct whose :req_options is nil" do
+      adapter = fn request ->
+        {request, %Req.Response{status: 200, body: %{"ok" => true}, headers: %{}}}
+      end
+
+      client = %Humaans{
+        access_token: "tok",
+        base_url: "https://app.humaans.io/api",
+        http_client: HumaansReq,
+        req_options: nil
+      }
+
+      request_opts = [
+        method: :get,
+        url: "/people",
+        headers: [{"Accept", "application/json"}],
+        adapter: adapter
+      ]
+
+      assert {:ok, _} = HumaansReq.request(client, request_opts)
+    end
+
+    test "does not allow req_options to override :base_url or :auth" do
+      adapter = fn request ->
+        send(self(), {:request, request})
+        {request, %Req.Response{status: 200, body: %{"ok" => true}, headers: %{}}}
+      end
+
+      client = %Humaans{
+        access_token: "real-token",
+        base_url: "https://app.humaans.io/api",
+        http_client: HumaansReq,
+        req_options: [
+          base_url: "https://evil.example.com",
+          auth: {:bearer, "leaked-token"}
+        ]
+      }
+
+      request_opts = [
+        method: :get,
+        url: "/people",
+        headers: [{"Accept", "application/json"}],
+        adapter: adapter
+      ]
+
+      assert {:ok, _} = HumaansReq.request(client, request_opts)
+
+      assert_received {:request, request}
+      assert request.options[:base_url] == "https://app.humaans.io/api"
+      assert request.options[:auth] == {:bearer, "real-token"}
+    end
   end
 
   defp setup_test(method, url, response_body, status \\ 200, extra_opts \\ []) do

--- a/test/humaans/http_client/req_test.exs
+++ b/test/humaans/http_client/req_test.exs
@@ -92,6 +92,35 @@ defmodule Humaans.HTTPClient.ReqTest do
 
       assert result == {:error, error_response}
     end
+
+    test "merges client.req_options into the Req config" do
+      # The adapter sees the merged Req.Request and lets us assert that
+      # req_options from the client made it through.
+      adapter = fn request ->
+        send(self(), {:request_options, request.options})
+        {request, %Req.Response{status: 200, body: %{"ok" => true}, headers: %{}}}
+      end
+
+      client = %Humaans{
+        access_token: "tok",
+        base_url: "https://app.humaans.io/api",
+        http_client: HumaansReq,
+        req_options: [connect_options: [timeout: 7_777], retry: false]
+      }
+
+      request_opts = [
+        method: :get,
+        url: "/people",
+        headers: [{"Accept", "application/json"}],
+        adapter: adapter
+      ]
+
+      assert {:ok, _} = HumaansReq.request(client, request_opts)
+
+      assert_received {:request_options, options}
+      assert options[:connect_options] == [timeout: 7_777]
+      assert options[:retry] == false
+    end
   end
 
   defp setup_test(method, url, response_body, status \\ 200, extra_opts \\ []) do

--- a/test/humaans_test.exs
+++ b/test/humaans_test.exs
@@ -27,6 +27,39 @@ defmodule HumaansTest do
       assert client.base_url == "https://app.humaans.io/api"
       assert client.http_client == Humaans.MockHTTPClient
     end
+
+    test "req_options defaults to []" do
+      client = Humaans.new(access_token: "some api key")
+
+      assert client.req_options == []
+    end
+
+    test "req_options accepts a keyword list" do
+      client =
+        Humaans.new(access_token: "some api key", req_options: [retry: false, max_retries: 0])
+
+      assert client.req_options == [retry: false, max_retries: 0]
+    end
+
+    test "req_options coerces nil to []" do
+      client = Humaans.new(access_token: "some api key", req_options: nil)
+
+      assert client.req_options == []
+    end
+
+    test "req_options raises ArgumentError for non-keyword list" do
+      assert_raise ArgumentError, ~r/:req_options must be a keyword list/, fn ->
+        Humaans.new(access_token: "some api key", req_options: %{retry: false})
+      end
+
+      assert_raise ArgumentError, ~r/:req_options must be a keyword list/, fn ->
+        Humaans.new(access_token: "some api key", req_options: "not a list")
+      end
+
+      assert_raise ArgumentError, ~r/:req_options must be a keyword list/, fn ->
+        Humaans.new(access_token: "some api key", req_options: [1, 2, 3])
+      end
+    end
   end
 
   describe "struct" do


### PR DESCRIPTION
:tipping_hand_person: These changes add a `:req_options` option to `Humaans.new/1` so callers can tune the underlying `Req` client (timeouts, plugins, etc.) without having to implement the full `Humaans.HTTPClient.Behaviour`.

## Summary

- Accept `:req_options` (keyword list) on `Humaans.new/1`; defaults to `[]`.
- Merged into the base `Req` config inside `Humaans.HTTPClient.Req` before `Req.merge/2` applies the per-request options.
- Common case becomes a one-liner:

  ```elixir
  Humaans.new(
    access_token: "...",
    req_options: [connect_options: [timeout: 30_000], retry: :transient]
  )
  ```

- The behaviour-based escape hatch is still available for callers needing full control.

## Test plan

- [x] `mix test` passes; new test asserts options reach `Req.Request.options`
- [x] `mix credo --strict` clean
- [ ] Smoke test against a real tenant with a custom timeout