### PR TITLE
feat(http_client): retry transient failures with bounded backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ client = Humaans.new(access_token: "YOUR_ACCESS_TOKEN")
 {:ok, companies} = Humaans.companies().list(client)
 ```
 
+### Rate-limit retries
+
+The default HTTP client retries transient failures (status 408, 429, 500, 502, 503, 504) up to 3 times with exponential backoff, honouring the `Retry-After` header. To opt out, pass `req_options: [retry: false]` to `Humaans.new/1`.
+
 ### Available resources
 
 - `Humaans.People` - Work with people resources

--- a/lib/humaans/http_client/req.ex
+++ b/lib/humaans/http_client/req.ex
@@ -5,6 +5,19 @@ defmodule Humaans.HTTPClient.Req do
   This module is used by default when you create a new Humaans client without
   specifying a custom HTTP client.
 
+  ## Rate-limit retries
+
+  By default this client enables Req's `:transient` retry strategy with
+  `max_retries: 3`. That means responses with status 408, 429, 500, 502, 503,
+  and 504 are automatically retried with exponential backoff, honouring the
+  `Retry-After` header when the API includes one. For the Humaans API the
+  practical effect is that bursty bulk reads no longer fail outright on a
+  single rate-limit hit.
+
+  To opt out, set `retry: false` in your `:req_options`:
+
+      Humaans.new(access_token: "...", req_options: [retry: false])
+
   ## Customization
 
   For most tweaks (timeouts, retries, plugins), pass `:req_options` directly
@@ -75,7 +88,9 @@ defmodule Humaans.HTTPClient.Req do
       |> Keyword.drop([:base_url, :auth])
 
     base =
-      Keyword.merge(req_options,
+      [retry: :transient, max_retries: 3]
+      |> Keyword.merge(req_options)
+      |> Keyword.merge(
         base_url: client.base_url,
         auth: {:bearer, client.access_token}
       )

--- a/test/humaans/http_client/req_test.exs
+++ b/test/humaans/http_client/req_test.exs
@@ -93,9 +93,89 @@ defmodule Humaans.HTTPClient.ReqTest do
       assert result == {:error, error_response}
     end
 
+    test "retries on 429 and eventually succeeds", %{client: client} do
+      {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+      adapter = fn request ->
+        n = Agent.get_and_update(counter, fn n -> {n + 1, n + 1} end)
+
+        if n <= 2 do
+          {request,
+           %Req.Response{
+             status: 429,
+             body: %{"error" => "rate_limited"},
+             headers: %{"retry-after" => ["0"]}
+           }}
+        else
+          {request, %Req.Response{status: 200, body: %{"ok" => true}, headers: %{}}}
+        end
+      end
+
+      request_opts = [
+        method: :get,
+        url: "/people",
+        headers: [{"Accept", "application/json"}],
+        adapter: adapter,
+        retry_delay: fn _ -> 0 end
+      ]
+
+      assert {:ok, %Req.Response{status: 200}} = HumaansReq.request(client, request_opts)
+      assert Agent.get(counter, & &1) == 3
+    end
+
+    test "stops retrying after max_retries", %{client: client} do
+      {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+      adapter = fn request ->
+        Agent.update(counter, &(&1 + 1))
+
+        {request,
+         %Req.Response{
+           status: 429,
+           body: %{"error" => "rate_limited"},
+           headers: %{"retry-after" => ["0"]}
+         }}
+      end
+
+      request_opts = [
+        method: :get,
+        url: "/people",
+        headers: [{"Accept", "application/json"}],
+        adapter: adapter,
+        retry_delay: fn _ -> 0 end
+      ]
+
+      assert {:ok, %Req.Response{status: 429}} = HumaansReq.request(client, request_opts)
+      assert Agent.get(counter, & &1) == 4
+    end
+
+    test "retry can be disabled via per-request opts", %{client: client} do
+      {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+      adapter = fn request ->
+        Agent.update(counter, &(&1 + 1))
+
+        {request,
+         %Req.Response{
+           status: 429,
+           body: %{"error" => "rate_limited"},
+           headers: %{}
+         }}
+      end
+
+      request_opts = [
+        method: :get,
+        url: "/people",
+        headers: [{"Accept", "application/json"}],
+        adapter: adapter,
+        retry: false
+      ]
+
+      assert {:ok, %Req.Response{status: 429}} = HumaansReq.request(client, request_opts)
+      assert Agent.get(counter, & &1) == 1
+    end
+
     test "merges client.req_options into the Req config" do
-      # The adapter sees the merged Req.Request and lets us assert that
-      # req_options from the client made it through.
       adapter = fn request ->
         send(self(), {:request_options, request.options})
         {request, %Req.Response{status: 200, body: %{"ok" => true}, headers: %{}}}


### PR DESCRIPTION
:tipping_hand_person: These changes make the default HTTP client retry transient failures (408/429/500/502/503/504) up to 3 times with exponential backoff, honouring `Retry-After`, so bulk reads no longer fail outright on a single rate-limit hit.

## Summary

- Default `Humaans.HTTPClient.Req` now uses `retry: :transient, max_retries: 3`.
- `Retry-After` is honoured automatically by Req when present.
- Callers can opt out per-request (`retry: false` in request opts) or globally via `req_options: [retry: false]` on `Humaans.new/1`.

## Test plan

- [x] `mix test` passes; new tests cover (1) retry-then-succeed on 429, (2) bounded retry budget, (3) opt-out via `retry: false`
- [x] `mix credo --strict` clean
- [ ] Smoke test against a tenant that's been rate-limited to confirm `Retry-After` is honoured

## Notes

- Test output now includes Req's own retry warning logs; suppressing them is left as follow-up polish.