### PR TITLE
docs(claude): drop reference to non-existent Humaans.Response

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ Humaans.new/1
 
 **Resource modules** — Each resource (`People`, `Companies`, `BankAccounts`, `Compensations`, `CompensationTypes`, `TimesheetEntries`, `TimesheetSubmissions`) exposes whichever of `list/2`, `create/2`, `retrieve/2`, `update/3`, `delete/2` the API supports. All return `{:ok, struct}` or `{:error, reason}`.
 
-**Resource structs** — Live in `lib/humaans/resources/`. Use `ExConstructor` for automatic camelCase→snake_case JSON mapping. `Humaans.Response` holds raw HTTP responses (`status`, `headers`, `body`).
+**Resource structs** — Live in `lib/humaans/resources/`. Use `ExConstructor` for automatic camelCase→snake_case JSON mapping. The HTTP-layer response (`status`, `headers`, `body`) is the raw map returned by `Req.Response`; `Humaans.ResponseHandler` consumes it directly.
 
 **Response handling** — `Humaans.ResponseHandler` unwraps `{"data": [...]}` envelopes and converts payloads to typed structs.
 


### PR DESCRIPTION
:tipping_hand_person: These changes correct a stale sentence in CLAUDE.md that pointed contributors at a `Humaans.Response` module which never existed.

## Summary

- Replace the stale `Humaans.Response holds raw HTTP responses` sentence with an accurate description: `Humaans.ResponseHandler` consumes the `Req.Response` map directly.
- No code changes.

## Test plan

- [x] `grep -r 'Humaans.Response' lib/ test/` returns only `ResponseHandler` references
- [x] `mix test` unaffected (docs only)