### PR TITLE
feat(webhooks): add HMAC-SHA256 signature verification helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,17 @@ client = Humaans.new(access_token: "YOUR_ACCESS_TOKEN")
 
 The default HTTP client retries transient failures (status 408, 429, 500, 502, 503, 504) up to 3 times with exponential backoff, honouring the `Retry-After` header. To opt out, pass `req_options: [retry: false]` to `Humaans.new/1`.
 
+### Webhooks
+
+Verify HMAC-SHA256 signatures on incoming webhook deliveries with `Humaans.Webhooks.verify_signature/3`. Pass the **raw** request body (not the re-encoded JSON):
+
+```elixir
+case Humaans.Webhooks.verify_signature(raw_body, signature_header, secret) do
+  :ok -> handle_event(raw_body)
+  {:error, :invalid_signature} -> {:error, :unauthorized}
+end
+```
+
 ### Available resources
 
 - `Humaans.People` - Work with people resources

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Verify HMAC-SHA256 signatures on incoming webhook deliveries with `Humaans.Webho
 case Humaans.Webhooks.verify_signature(raw_body, signature_header, secret) do
   :ok -> handle_event(raw_body)
   {:error, :invalid_signature} -> {:error, :unauthorized}
+  {:error, :missing_signature} -> {:error, :unauthorized}
+  {:error, :missing_secret} -> {:error, :misconfigured}
 end
 ```
 

--- a/lib/humaans.ex
+++ b/lib/humaans.ex
@@ -198,4 +198,12 @@ defmodule Humaans do
   page and `stream/3` for lazily iterating all results.
   """
   def pagination, do: Humaans.Pagination
+
+  @doc """
+  Access webhook helpers.
+
+  Returns `Humaans.Webhooks`, which provides `verify_signature/3` for
+  verifying HMAC-SHA256 webhook signatures.
+  """
+  def webhooks, do: Humaans.Webhooks
 end

--- a/lib/humaans/webhooks.ex
+++ b/lib/humaans/webhooks.ex
@@ -56,7 +56,11 @@ defmodule Humaans.Webhooks do
       iex> Humaans.Webhooks.verify_signature("body", nil, "secret")
       {:error, :missing_signature}
   """
-  @spec verify_signature(payload :: binary(), signature :: String.t() | nil, secret :: String.t()) ::
+  @spec verify_signature(
+          payload :: binary(),
+          signature :: String.t() | nil,
+          secret :: String.t() | nil
+        ) ::
           :ok | {:error, :invalid_signature | :missing_signature | :missing_secret}
   def verify_signature(_payload, nil, _secret), do: {:error, :missing_signature}
   def verify_signature(_payload, "", _secret), do: {:error, :missing_signature}

--- a/lib/humaans/webhooks.ex
+++ b/lib/humaans/webhooks.ex
@@ -78,12 +78,19 @@ defmodule Humaans.Webhooks do
   defp strip_prefix("sha256=" <> rest), do: rest
   defp strip_prefix(other), do: other
 
-  # Constant-time string comparison. :crypto.hash_equals/2 is available since
-  # OTP 25, but only accepts equal-length binaries; the length check has to
-  # happen first (and discloses length, which is unavoidable).
+  import Bitwise, only: [bor: 2, bxor: 2]
+
+  # Constant-time comparison over equal-length binaries. The length check has
+  # to happen first (and discloses length, which is unavoidable).
   defp secure_compare(a, b) when byte_size(a) == byte_size(b) do
-    :crypto.hash_equals(a, b)
+    compare_bytes(a, b, 0) === 0
   end
 
   defp secure_compare(_, _), do: false
+
+  defp compare_bytes(<<x, rest_a::binary>>, <<y, rest_b::binary>>, acc) do
+    compare_bytes(rest_a, rest_b, bor(acc, bxor(x, y)))
+  end
+
+  defp compare_bytes(<<>>, <<>>, acc), do: acc
 end

--- a/lib/humaans/webhooks.ex
+++ b/lib/humaans/webhooks.ex
@@ -66,7 +66,7 @@ defmodule Humaans.Webhooks do
   def verify_signature(payload, signature, secret)
       when is_binary(payload) and is_binary(signature) and is_binary(secret) do
     expected = :crypto.mac(:hmac, :sha256, secret, payload) |> Base.encode16(case: :lower)
-    provided = strip_prefix(signature) |> String.downcase()
+    provided = signature |> String.downcase() |> strip_prefix()
 
     if secure_compare(expected, provided) do
       :ok

--- a/lib/humaans/webhooks.ex
+++ b/lib/humaans/webhooks.ex
@@ -1,0 +1,89 @@
+defmodule Humaans.Webhooks do
+  @moduledoc """
+  Helpers for working with Humaans webhooks.
+
+  Humaans signs webhook payloads with HMAC-SHA256 using your endpoint's
+  signing secret. Verifying the signature on every delivery is required —
+  treat any unverified payload as untrusted input.
+
+  ## Verifying a delivery
+
+      defp verify(conn, secret) do
+        {:ok, raw_body, conn} = Plug.Conn.read_body(conn)
+        signature = Plug.Conn.get_req_header(conn, "x-humaans-signature") |> List.first()
+
+        case Humaans.Webhooks.verify_signature(raw_body, signature, secret) do
+          :ok -> {:ok, conn, raw_body}
+          {:error, _reason} = err -> err
+        end
+      end
+
+  Always pass the **raw** request body to `verify_signature/3`. Re-serialised
+  JSON will not match because byte-level differences (key ordering,
+  whitespace) change the HMAC.
+  """
+
+  @doc """
+  Verifies a webhook signature against the raw request body.
+
+  Computes `HMAC-SHA256(secret, payload)` and compares it to `signature` in
+  constant time.
+
+  Accepts the signature as either a raw hex string (`"abc123..."`) or with a
+  `sha256=` prefix (`"sha256=abc123..."`), so it works regardless of the
+  exact convention used by the sender.
+
+  ## Returns
+
+  * `:ok` - Signature matches.
+  * `{:error, :invalid_signature}` - Signature does not match the payload.
+  * `{:error, :missing_signature}` - `signature` is `nil` or empty.
+  * `{:error, :missing_secret}` - `secret` is `nil` or empty.
+
+  ## Examples
+
+      iex> body = ~s({"event":"person.updated"})
+      iex> secret = "test-secret"
+      iex> sig =
+      ...>   :crypto.mac(:hmac, :sha256, secret, body)
+      ...>   |> Base.encode16(case: :lower)
+      iex> Humaans.Webhooks.verify_signature(body, sig, secret)
+      :ok
+
+      iex> Humaans.Webhooks.verify_signature("body", "deadbeef", "secret")
+      {:error, :invalid_signature}
+
+      iex> Humaans.Webhooks.verify_signature("body", nil, "secret")
+      {:error, :missing_signature}
+  """
+  @spec verify_signature(payload :: binary(), signature :: String.t() | nil, secret :: String.t()) ::
+          :ok | {:error, :invalid_signature | :missing_signature | :missing_secret}
+  def verify_signature(_payload, nil, _secret), do: {:error, :missing_signature}
+  def verify_signature(_payload, "", _secret), do: {:error, :missing_signature}
+  def verify_signature(_payload, _signature, nil), do: {:error, :missing_secret}
+  def verify_signature(_payload, _signature, ""), do: {:error, :missing_secret}
+
+  def verify_signature(payload, signature, secret)
+      when is_binary(payload) and is_binary(signature) and is_binary(secret) do
+    expected = :crypto.mac(:hmac, :sha256, secret, payload) |> Base.encode16(case: :lower)
+    provided = strip_prefix(signature) |> String.downcase()
+
+    if secure_compare(expected, provided) do
+      :ok
+    else
+      {:error, :invalid_signature}
+    end
+  end
+
+  defp strip_prefix("sha256=" <> rest), do: rest
+  defp strip_prefix(other), do: other
+
+  # Constant-time string comparison. :crypto.hash_equals/2 is available since
+  # OTP 25, but only accepts equal-length binaries; the length check has to
+  # happen first (and discloses length, which is unavoidable).
+  defp secure_compare(a, b) when byte_size(a) == byte_size(b) do
+    :crypto.hash_equals(a, b)
+  end
+
+  defp secure_compare(_, _), do: false
+end

--- a/test/humaans/webhooks_test.exs
+++ b/test/humaans/webhooks_test.exs
@@ -21,6 +21,16 @@ defmodule Humaans.WebhooksTest do
       assert Humaans.Webhooks.verify_signature(@body, sig, @secret) == :ok
     end
 
+    test "accepts an uppercase SHA256= prefixed signature" do
+      sig = "SHA256=" <> signature_for(@body, @secret)
+      assert Humaans.Webhooks.verify_signature(@body, sig, @secret) == :ok
+    end
+
+    test "accepts a mixed-case Sha256= prefixed signature" do
+      sig = "Sha256=" <> signature_for(@body, @secret)
+      assert Humaans.Webhooks.verify_signature(@body, sig, @secret) == :ok
+    end
+
     test "is case-insensitive on the hex digest" do
       sig = signature_for(@body, @secret) |> String.upcase()
       assert Humaans.Webhooks.verify_signature(@body, sig, @secret) == :ok

--- a/test/humaans/webhooks_test.exs
+++ b/test/humaans/webhooks_test.exs
@@ -1,0 +1,73 @@
+defmodule Humaans.WebhooksTest do
+  use ExUnit.Case, async: true
+  doctest Humaans.Webhooks
+
+  @secret "shhh-very-secret"
+  @body ~s({"event":"person.updated","data":{"id":"abc"}})
+
+  defp signature_for(body, secret) do
+    :crypto.mac(:hmac, :sha256, secret, body)
+    |> Base.encode16(case: :lower)
+  end
+
+  describe "verify_signature/3" do
+    test "returns :ok for a valid signature" do
+      sig = signature_for(@body, @secret)
+      assert Humaans.Webhooks.verify_signature(@body, sig, @secret) == :ok
+    end
+
+    test "accepts a sha256= prefixed signature" do
+      sig = "sha256=" <> signature_for(@body, @secret)
+      assert Humaans.Webhooks.verify_signature(@body, sig, @secret) == :ok
+    end
+
+    test "is case-insensitive on the hex digest" do
+      sig = signature_for(@body, @secret) |> String.upcase()
+      assert Humaans.Webhooks.verify_signature(@body, sig, @secret) == :ok
+    end
+
+    test "rejects a tampered body" do
+      sig = signature_for(@body, @secret)
+      tampered = @body <> " "
+
+      assert Humaans.Webhooks.verify_signature(tampered, sig, @secret) ==
+               {:error, :invalid_signature}
+    end
+
+    test "rejects a wrong secret" do
+      sig = signature_for(@body, @secret)
+
+      assert Humaans.Webhooks.verify_signature(@body, sig, "wrong-secret") ==
+               {:error, :invalid_signature}
+    end
+
+    test "rejects mismatched length signatures without raising" do
+      assert Humaans.Webhooks.verify_signature(@body, "deadbeef", @secret) ==
+               {:error, :invalid_signature}
+    end
+
+    test "returns :missing_signature for nil signature" do
+      assert Humaans.Webhooks.verify_signature(@body, nil, @secret) ==
+               {:error, :missing_signature}
+    end
+
+    test "returns :missing_signature for empty signature" do
+      assert Humaans.Webhooks.verify_signature(@body, "", @secret) ==
+               {:error, :missing_signature}
+    end
+
+    test "returns :missing_secret for nil secret" do
+      sig = signature_for(@body, @secret)
+
+      assert Humaans.Webhooks.verify_signature(@body, sig, nil) ==
+               {:error, :missing_secret}
+    end
+
+    test "returns :missing_secret for empty secret" do
+      sig = signature_for(@body, @secret)
+
+      assert Humaans.Webhooks.verify_signature(@body, sig, "") ==
+               {:error, :missing_secret}
+    end
+  end
+end

--- a/test/humaans_test.exs
+++ b/test/humaans_test.exs
@@ -124,4 +124,8 @@ defmodule HumaansTest do
   test "pagination/0 returns the Pagination module" do
     assert Humaans.pagination() == Humaans.Pagination
   end
+
+  test "webhooks/0 returns the Webhooks module" do
+    assert Humaans.webhooks() == Humaans.Webhooks
+  end
 end


### PR DESCRIPTION
:tipping_hand_person: These changes add `Humaans.Webhooks.verify_signature/3` so consumers can verify HMAC-SHA256 webhook deliveries without re-deriving constant-time comparison and signature-stripping logic in every project.

## Summary

- New module `Humaans.Webhooks` exposing `verify_signature(payload, signature, secret)`.
- Returns `:ok | {:error, :invalid_signature | :missing_signature | :missing_secret}`.
- Accepts the signature with or without a `sha256=` / `SHA256=` prefix, case-insensitively, and matches the hex digest case-insensitively.
- Constant-time comparison via a portable byte-by-byte XOR-OR accumulator over equal-length binaries (using `Bitwise.bxor/2` and `Bitwise.bor/2`); no dependency on `:crypto.hash_equals/2` or a specific OTP version. Length is checked first and is unavoidably disclosed.
- Typespec accepts `String.t() | nil` for both `signature` and `secret`, matching the documented `:missing_signature` / `:missing_secret` returns.
- Adds `Humaans.webhooks/0` accessor for symmetry with the other top-level helpers.

## Test plan

- [x] `mix test` passes (3 doctests + 12 unit tests covering valid, tampered, wrong-secret, missing-*, lower/upper/mixed-case prefix, and case-insensitive digest paths, plus the `webhooks/0` accessor assertion)
- [x] `mix credo --strict` clean
- [x] Wire into a Plug endpoint and verify against a real Humaans webhook delivery