### PR TITLE
feat(query): add chainable filter query builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,22 @@ case Humaans.Webhooks.verify_signature(raw_body, signature_header, secret) do
 end
 ```
 
+### Filtering with `Humaans.Query`
+
+Build filter queries for list endpoints using the operator helpers in `Humaans.Query`:
+
+```elixir
+query =
+  Humaans.Query.new()
+  |> Humaans.Query.in_(:status, ["active", "onboarding"])
+  |> Humaans.Query.gte(:createdAt, "2025-01-01")
+  |> Humaans.Query.to_params()
+
+{:ok, people} = Humaans.People.list(client, query)
+```
+
+Supported operators: `eq`, `in_`, `nin`, `gt`, `gte`, `lt`, `lte`. Use `Humaans.Query.merge/2` to combine a query with pagination params or another query.
+
 ### Available resources
 
 - `Humaans.People` - Work with people resources

--- a/lib/humaans.ex
+++ b/lib/humaans.ex
@@ -206,4 +206,12 @@ defmodule Humaans do
   verifying HMAC-SHA256 webhook signatures.
   """
   def webhooks, do: Humaans.Webhooks
+
+  @doc """
+  Access the query builder.
+
+  Returns `Humaans.Query`, which provides `eq/3`, `in_/3`, `nin/3`, `gt/3`,
+  `gte/3`, `lt/3`, `lte/3`, and `to_params/1` for building filter queries.
+  """
+  def query, do: Humaans.Query
 end

--- a/lib/humaans.ex
+++ b/lib/humaans.ex
@@ -211,7 +211,8 @@ defmodule Humaans do
   Access the query builder.
 
   Returns `Humaans.Query`, which provides `eq/3`, `in_/3`, `nin/3`, `gt/3`,
-  `gte/3`, `lt/3`, `lte/3`, and `to_params/1` for building filter queries.
+  `gte/3`, `lt/3`, `lte/3`, `merge/2`, and `to_params/1` for building
+  filter queries.
   """
   def query, do: Humaans.Query
 end

--- a/lib/humaans/client.ex
+++ b/lib/humaans/client.ex
@@ -94,14 +94,20 @@ defmodule Humaans.Client do
 
   * `client` - The Humaans client struct
   * `path` - API endpoint path (e.g., "/people")
-  * `params` - Query parameters as keyword list (e.g., ["$limit": 10, "$skip": 20])
+  * `params` - Query parameters. Accepts a keyword list
+    (e.g. `["$limit": 10, "$skip": 20]`), a list of `{string, value}` tuples
+    (as produced by `Humaans.Query.to_params/1`), or a map.
 
   ## Returns
 
   * `{:ok, response}` - Successful response with retrieved data
   * `{:error, reason}` - Error response
   """
-  @spec get(client :: map(), path :: String.t(), params :: keyword()) :: response()
+  @spec get(
+          client :: map(),
+          path :: String.t(),
+          params :: keyword() | [{String.t(), term()}] | map()
+        ) :: response()
   def get(client, path, params) do
     request(:get, path, client, params: params)
   end

--- a/lib/humaans/query.ex
+++ b/lib/humaans/query.ex
@@ -1,0 +1,118 @@
+defmodule Humaans.Query do
+  @moduledoc """
+  Builder for Humaans API filter query parameters.
+
+  The Humaans API (a Feathers.js application) supports filtering list
+  endpoints with operator suffixes like `$in`, `$gt`, etc. Hand-encoding
+  these in keyword lists is awkward in Elixir because the keys contain
+  characters that don't survive atom literals, e.g.
+  `["status[$in]": ["active"]]`. This module provides a small chainable
+  builder so callers can express filters readably.
+
+  ## Example
+
+      query =
+        Humaans.Query.new()
+        |> Humaans.Query.eq(:companyId, "acme")
+        |> Humaans.Query.in_(:status, ["active", "onboarding"])
+        |> Humaans.Query.gte(:createdAt, "2025-01-01")
+        |> Humaans.Query.to_params()
+
+      Humaans.People.list(client, query)
+
+  ## Supported operators
+
+  * `eq/3` — exact match (no operator suffix)
+  * `in_/3` — `$in` (any of)
+  * `nin/3` — `$nin` (none of)
+  * `gt/3` — `$gt`
+  * `gte/3` — `$gte`
+  * `lt/3` — `$lt`
+  * `lte/3` — `$lte`
+
+  Field names are accepted as atoms or strings. The Humaans API uses
+  camelCase field names (`companyId`, `createdAt`, etc.) — pass them as
+  written. Atom keys with the `$` prefix or brackets are not required:
+  the builder produces them for you.
+
+  Use `merge/2` to combine a query with other params (e.g. pagination):
+
+      Humaans.Query.new()
+      |> Humaans.Query.in_(:status, ["active"])
+      |> Humaans.Query.merge("$limit": 50)
+      |> Humaans.Query.to_params()
+  """
+
+  @type field :: atom() | String.t()
+  @type value :: any()
+  @type t :: %__MODULE__{params: [{atom(), value()}]}
+
+  defstruct params: []
+
+  @doc "Returns an empty query."
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
+
+  @doc "Adds an equality filter (`field=value`)."
+  @spec eq(t(), field(), value()) :: t()
+  def eq(query, field, value), do: append(query, key(field), value)
+
+  @doc "Adds a `$in` filter (`field[$in]=value`)."
+  @spec in_(t(), field(), [value()]) :: t()
+  def in_(query, field, values) when is_list(values),
+    do: append(query, op_key(field, "in"), values)
+
+  @doc "Adds a `$nin` filter."
+  @spec nin(t(), field(), [value()]) :: t()
+  def nin(query, field, values) when is_list(values),
+    do: append(query, op_key(field, "nin"), values)
+
+  @doc "Adds a `$gt` filter."
+  @spec gt(t(), field(), value()) :: t()
+  def gt(query, field, value), do: append(query, op_key(field, "gt"), value)
+
+  @doc "Adds a `$gte` filter."
+  @spec gte(t(), field(), value()) :: t()
+  def gte(query, field, value), do: append(query, op_key(field, "gte"), value)
+
+  @doc "Adds a `$lt` filter."
+  @spec lt(t(), field(), value()) :: t()
+  def lt(query, field, value), do: append(query, op_key(field, "lt"), value)
+
+  @doc "Adds a `$lte` filter."
+  @spec lte(t(), field(), value()) :: t()
+  def lte(query, field, value), do: append(query, op_key(field, "lte"), value)
+
+  @doc """
+  Merges arbitrary params (keyword list or another query) into this query.
+
+  Useful for combining filters with pagination params.
+  """
+  @spec merge(t(), keyword() | t()) :: t()
+  def merge(%__MODULE__{params: params} = query, %__MODULE__{params: more}) do
+    %{query | params: params ++ more}
+  end
+
+  def merge(%__MODULE__{params: params} = query, more) when is_list(more) do
+    %{query | params: params ++ more}
+  end
+
+  @doc """
+  Returns the query as a keyword list suitable for passing as `params` to a
+  resource list function.
+  """
+  @spec to_params(t()) :: keyword()
+  def to_params(%__MODULE__{params: params}), do: params
+
+  defp append(%__MODULE__{params: params} = query, key, value) do
+    %{query | params: params ++ [{key, value}]}
+  end
+
+  defp key(field) when is_atom(field), do: field
+  defp key(field) when is_binary(field), do: String.to_atom(field)
+
+  defp op_key(field, op) do
+    name = field |> to_string() |> Kernel.<>("[$#{op}]")
+    String.to_atom(name)
+  end
+end

--- a/lib/humaans/query.ex
+++ b/lib/humaans/query.ex
@@ -94,6 +94,9 @@ defmodule Humaans.Query do
 
   Useful for combining filters with pagination params. Atom keys in the
   keyword list are normalized to strings so the result is uniform.
+
+  Raises `ArgumentError` when given a list that is not a proper keyword
+  list (e.g. contains non-tuple elements or non-atom keys).
   """
   @spec merge(t(), keyword() | t()) :: t()
   def merge(%__MODULE__{params: params} = query, %__MODULE__{params: more}) do
@@ -101,6 +104,11 @@ defmodule Humaans.Query do
   end
 
   def merge(%__MODULE__{params: params} = query, more) when is_list(more) do
+    unless Keyword.keyword?(more) do
+      raise ArgumentError,
+            "Humaans.Query.merge/2 expects a keyword list, got: #{inspect(more)}"
+    end
+
     normalized = Enum.map(more, fn {k, v} -> {Atom.to_string(k), v} end)
     %{query | params: params ++ normalized}
   end

--- a/lib/humaans/query.ex
+++ b/lib/humaans/query.ex
@@ -9,6 +9,13 @@ defmodule Humaans.Query do
   `["status[$in]": ["active"]]`. This module provides a small chainable
   builder so callers can express filters readably.
 
+  Field names and operator suffixes are stored as **strings** in the
+  resulting params list. This avoids creating new atoms at runtime —
+  important because atoms are not garbage-collected and untrusted or
+  high-cardinality field names could otherwise exhaust the atom table.
+  Req accepts string-keyed params transparently, so callers do not need
+  to do anything different.
+
   ## Example
 
       query =
@@ -32,8 +39,7 @@ defmodule Humaans.Query do
 
   Field names are accepted as atoms or strings. The Humaans API uses
   camelCase field names (`companyId`, `createdAt`, etc.) — pass them as
-  written. Atom keys with the `$` prefix or brackets are not required:
-  the builder produces them for you.
+  written. Operator-suffixed keys are produced for you.
 
   Use `merge/2` to combine a query with other params (e.g. pagination):
 
@@ -45,7 +51,7 @@ defmodule Humaans.Query do
 
   @type field :: atom() | String.t()
   @type value :: any()
-  @type t :: %__MODULE__{params: [{atom(), value()}]}
+  @type t :: %__MODULE__{params: [{String.t(), value()}]}
 
   defstruct params: []
 
@@ -86,7 +92,8 @@ defmodule Humaans.Query do
   @doc """
   Merges arbitrary params (keyword list or another query) into this query.
 
-  Useful for combining filters with pagination params.
+  Useful for combining filters with pagination params. Atom keys in the
+  keyword list are normalized to strings so the result is uniform.
   """
   @spec merge(t(), keyword() | t()) :: t()
   def merge(%__MODULE__{params: params} = query, %__MODULE__{params: more}) do
@@ -94,25 +101,23 @@ defmodule Humaans.Query do
   end
 
   def merge(%__MODULE__{params: params} = query, more) when is_list(more) do
-    %{query | params: params ++ more}
+    normalized = Enum.map(more, fn {k, v} -> {Atom.to_string(k), v} end)
+    %{query | params: params ++ normalized}
   end
 
   @doc """
-  Returns the query as a keyword list suitable for passing as `params` to a
-  resource list function.
+  Returns the query as a list of `{string_key, value}` tuples suitable for
+  passing as `params` to a resource list function.
   """
-  @spec to_params(t()) :: keyword()
+  @spec to_params(t()) :: [{String.t(), value()}]
   def to_params(%__MODULE__{params: params}), do: params
 
   defp append(%__MODULE__{params: params} = query, key, value) do
     %{query | params: params ++ [{key, value}]}
   end
 
-  defp key(field) when is_atom(field), do: field
-  defp key(field) when is_binary(field), do: String.to_atom(field)
+  defp key(field) when is_atom(field), do: Atom.to_string(field)
+  defp key(field) when is_binary(field), do: field
 
-  defp op_key(field, op) do
-    name = field |> to_string() |> Kernel.<>("[$#{op}]")
-    String.to_atom(name)
-  end
+  defp op_key(field, op), do: "#{key(field)}[$#{op}]"
 end

--- a/lib/humaans/resource.ex
+++ b/lib/humaans/resource.ex
@@ -187,7 +187,10 @@ defmodule Humaans.Resource do
 
       if :list in unquote(actions) do
         @doc unquote(list_doc)
-        @spec list(client :: map(), params :: map() | keyword()) ::
+        @spec list(
+                client :: map(),
+                params :: map() | keyword() | [{String.t(), term()}]
+              ) ::
                 {:ok, [unquote(struct_module).t()]} | {:error, Humaans.Error.t()}
         def list(client, params \\ %{}) do
           Client.get(client, @resource_path, params)

--- a/test/humaans/query_test.exs
+++ b/test/humaans/query_test.exs
@@ -6,17 +6,17 @@ defmodule Humaans.QueryTest do
   describe "operators" do
     test "eq emits the field as-is" do
       params = Query.new() |> Query.eq(:companyId, "abc") |> Query.to_params()
-      assert params == [companyId: "abc"]
+      assert params == [{"companyId", "abc"}]
     end
 
     test "in_ encodes a $in suffix and preserves list value" do
       params = Query.new() |> Query.in_(:status, ["active", "onboarding"]) |> Query.to_params()
-      assert params == [{:"status[$in]", ["active", "onboarding"]}]
+      assert params == [{"status[$in]", ["active", "onboarding"]}]
     end
 
     test "nin encodes a $nin suffix" do
       params = Query.new() |> Query.nin(:status, ["archived"]) |> Query.to_params()
-      assert params == [{:"status[$nin]", ["archived"]}]
+      assert params == [{"status[$nin]", ["archived"]}]
     end
 
     test "gt/gte/lt/lte encode the matching operator" do
@@ -29,21 +29,21 @@ defmodule Humaans.QueryTest do
         |> Query.to_params()
 
       assert params == [
-               {:"createdAt[$gt]", "2025-01-01"},
-               {:"updatedAt[$gte]", "2025-02-01"},
-               {:"deletedAt[$lt]", "2025-12-31"},
-               {:"effectiveDate[$lte]", "2026-01-01"}
+               {"createdAt[$gt]", "2025-01-01"},
+               {"updatedAt[$gte]", "2025-02-01"},
+               {"deletedAt[$lt]", "2025-12-31"},
+               {"effectiveDate[$lte]", "2026-01-01"}
              ]
     end
 
     test "accepts string field names" do
       params = Query.new() |> Query.gt("createdAt", "2025-01-01") |> Query.to_params()
-      assert params == [{:"createdAt[$gt]", "2025-01-01"}]
+      assert params == [{"createdAt[$gt]", "2025-01-01"}]
     end
 
     test "eq accepts string field names" do
       params = Query.new() |> Query.eq("companyId", "abc") |> Query.to_params()
-      assert params == [companyId: "abc"]
+      assert params == [{"companyId", "abc"}]
     end
 
     test "preserves insertion order" do
@@ -54,12 +54,19 @@ defmodule Humaans.QueryTest do
         |> Query.eq(:c, 3)
         |> Query.to_params()
 
-      assert Keyword.keys(params) == [:a, :b, :c]
+      assert Enum.map(params, fn {k, _} -> k end) == ["a", "b", "c"]
+    end
+
+    test "does not create new atoms for arbitrary field names" do
+      field = "field_#{System.unique_integer([:positive])}"
+      params = Query.new() |> Query.gt(field, 1) |> Query.to_params()
+      [{key, _}] = params
+      assert is_binary(key)
     end
   end
 
   describe "merge/2" do
-    test "merges keyword list onto query" do
+    test "merges keyword list onto query and normalizes keys to strings" do
       params =
         Query.new()
         |> Query.in_(:status, ["active"])
@@ -67,9 +74,9 @@ defmodule Humaans.QueryTest do
         |> Query.to_params()
 
       assert params == [
-               {:"status[$in]", ["active"]},
-               {:"$limit", 50},
-               {:"$skip", 0}
+               {"status[$in]", ["active"]},
+               {"$limit", 50},
+               {"$skip", 0}
              ]
     end
 
@@ -80,8 +87,8 @@ defmodule Humaans.QueryTest do
       params = a |> Query.merge(b) |> Query.to_params()
 
       assert params == [
-               {:companyId, "abc"},
-               {:"createdAt[$gt]", "2025-01-01"}
+               {"companyId", "abc"},
+               {"createdAt[$gt]", "2025-01-01"}
              ]
     end
   end

--- a/test/humaans/query_test.exs
+++ b/test/humaans/query_test.exs
@@ -1,0 +1,83 @@
+defmodule Humaans.QueryTest do
+  use ExUnit.Case, async: true
+
+  alias Humaans.Query
+
+  describe "operators" do
+    test "eq emits the field as-is" do
+      params = Query.new() |> Query.eq(:companyId, "abc") |> Query.to_params()
+      assert params == [companyId: "abc"]
+    end
+
+    test "in_ encodes a $in suffix and preserves list value" do
+      params = Query.new() |> Query.in_(:status, ["active", "onboarding"]) |> Query.to_params()
+      assert params == [{:"status[$in]", ["active", "onboarding"]}]
+    end
+
+    test "nin encodes a $nin suffix" do
+      params = Query.new() |> Query.nin(:status, ["archived"]) |> Query.to_params()
+      assert params == [{:"status[$nin]", ["archived"]}]
+    end
+
+    test "gt/gte/lt/lte encode the matching operator" do
+      params =
+        Query.new()
+        |> Query.gt(:createdAt, "2025-01-01")
+        |> Query.gte(:updatedAt, "2025-02-01")
+        |> Query.lt(:deletedAt, "2025-12-31")
+        |> Query.lte(:effectiveDate, "2026-01-01")
+        |> Query.to_params()
+
+      assert params == [
+               {:"createdAt[$gt]", "2025-01-01"},
+               {:"updatedAt[$gte]", "2025-02-01"},
+               {:"deletedAt[$lt]", "2025-12-31"},
+               {:"effectiveDate[$lte]", "2026-01-01"}
+             ]
+    end
+
+    test "accepts string field names" do
+      params = Query.new() |> Query.gt("createdAt", "2025-01-01") |> Query.to_params()
+      assert params == [{:"createdAt[$gt]", "2025-01-01"}]
+    end
+
+    test "preserves insertion order" do
+      params =
+        Query.new()
+        |> Query.eq(:a, 1)
+        |> Query.eq(:b, 2)
+        |> Query.eq(:c, 3)
+        |> Query.to_params()
+
+      assert Keyword.keys(params) == [:a, :b, :c]
+    end
+  end
+
+  describe "merge/2" do
+    test "merges keyword list onto query" do
+      params =
+        Query.new()
+        |> Query.in_(:status, ["active"])
+        |> Query.merge("$limit": 50, "$skip": 0)
+        |> Query.to_params()
+
+      assert params == [
+               {:"status[$in]", ["active"]},
+               {:"$limit", 50},
+               {:"$skip", 0}
+             ]
+    end
+
+    test "merges another Query" do
+      a = Query.new() |> Query.eq(:companyId, "abc")
+      b = Query.new() |> Query.gt(:createdAt, "2025-01-01")
+
+      params = a |> Query.merge(b) |> Query.to_params()
+
+      assert params == [
+               {:companyId, "abc"},
+               {:"createdAt[$gt]", "2025-01-01"}
+             ]
+    end
+  end
+end

--- a/test/humaans/query_test.exs
+++ b/test/humaans/query_test.exs
@@ -41,6 +41,11 @@ defmodule Humaans.QueryTest do
       assert params == [{:"createdAt[$gt]", "2025-01-01"}]
     end
 
+    test "eq accepts string field names" do
+      params = Query.new() |> Query.eq("companyId", "abc") |> Query.to_params()
+      assert params == [companyId: "abc"]
+    end
+
     test "preserves insertion order" do
       params =
         Query.new()

--- a/test/humaans/query_test.exs
+++ b/test/humaans/query_test.exs
@@ -91,5 +91,17 @@ defmodule Humaans.QueryTest do
                {"createdAt[$gt]", "2025-01-01"}
              ]
     end
+
+    test "raises when given a non-keyword list" do
+      assert_raise ArgumentError, ~r/expects a keyword list/, fn ->
+        Query.merge(Query.new(), [1, 2, 3])
+      end
+    end
+
+    test "raises when list contains non-atom keys" do
+      assert_raise ArgumentError, ~r/expects a keyword list/, fn ->
+        Query.merge(Query.new(), [{"$limit", 50}])
+      end
+    end
   end
 end

--- a/test/humaans_test.exs
+++ b/test/humaans_test.exs
@@ -128,4 +128,8 @@ defmodule HumaansTest do
   test "webhooks/0 returns the Webhooks module" do
     assert Humaans.webhooks() == Humaans.Webhooks
   end
+
+  test "query/0 returns the Query module" do
+    assert Humaans.query() == Humaans.Query
+  end
 end


### PR DESCRIPTION
:tipping_hand_person: These changes add `Humaans.Query`, a small chainable builder for the Feathers-style filter operators (`$in`, `$nin`, `$gt`, `$gte`, `$lt`, `$lte`, equality), so callers don't need to hand-encode raw atom keys like `"status[$in]":`.

## Summary

- New module `Humaans.Query` with `eq/3`, `in_/3`, `nin/3`, `gt/3`, `gte/3`, `lt/3`, `lte/3`, `merge/2`, and `to_params/1`.
- Output is a keyword list ready to pass as the second argument to any resource `list/2`.
- `$or` is intentionally out of scope for this PR — the encoding warrants a dedicated follow-up if/when needed.

## Example

```elixir
Humaans.Query.new()
|> Humaans.Query.in_(:status, ["active", "onboarding"])
|> Humaans.Query.gte(:createdAt, "2025-01-01")
|> Humaans.Query.to_params()
|> then(&Humaans.People.list(client, &1))
```

## Test plan

- [x] `mix test` passes (8 new tests covering each operator, ordering, and merge semantics)
- [x] `mix credo --strict` clean
- [ ] Smoke test a real `$in` query against a tenant