### PR TITLE
feat(me, token_info): add singleton helpers for /me and /token-info

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ Supported operators: `eq`, `in_`, `nin`, `gt`, `gte`, `lt`, `lte`. Use `Humaans.
 - `Humaans.TimeAwayTypes` - Work with time away type resources
 - `Humaans.CustomFields` - Work with custom field definitions
 - `Humaans.CustomValues` - Work with custom value records
+- `Humaans.Me` - Retrieve the authenticated user's profile (`GET /me`)
+- `Humaans.TokenInfo` - Retrieve metadata about the current access token (`GET /token-info`)
 
 ## Development
 

--- a/lib/humaans.ex
+++ b/lib/humaans.ex
@@ -143,13 +143,6 @@ defmodule Humaans do
   end
 
   @doc """
-  Access the People API.
-
-  Returns the module that contains functions for working with people resources.
-  """
-  def people, do: Humaans.People
-
-  @doc """
   Access the Bank Accounts API.
 
   Returns the module that contains functions for working with bank account resources.
@@ -176,6 +169,52 @@ defmodule Humaans do
   Returns the module that contains functions for working with compensation resources.
   """
   def compensations, do: Humaans.Compensations
+
+  @doc """
+  Access the Custom Fields API.
+
+  Returns the module that contains functions for working with custom field resources.
+  """
+  def custom_fields, do: Humaans.CustomFields
+
+  @doc """
+  Access the Custom Values API.
+
+  Returns the module that contains functions for working with custom value resources.
+  """
+  def custom_values, do: Humaans.CustomValues
+
+  @doc """
+  Access the current user's profile.
+
+  Returns `Humaans.Me`, which exposes `get/1` for retrieving the
+  authenticated user's profile.
+  """
+  def me, do: Humaans.Me
+
+  @doc """
+  Access pagination helpers.
+
+  Returns `Humaans.Pagination`, which provides `page/4` for fetching a specific
+  page and `stream/3` for lazily iterating all results.
+  """
+  def pagination, do: Humaans.Pagination
+
+  @doc """
+  Access the People API.
+
+  Returns the module that contains functions for working with people resources.
+  """
+  def people, do: Humaans.People
+
+  @doc """
+  Access the query builder.
+
+  Returns `Humaans.Query`, which provides `eq/3`, `in_/3`, `nin/3`, `gt/3`,
+  `gte/3`, `lt/3`, `lte/3`, `merge/2`, and `to_params/1` for building
+  filter queries.
+  """
+  def query, do: Humaans.Query
 
   @doc """
   Access the Timesheet Entries API.
@@ -225,45 +264,6 @@ defmodule Humaans do
   Returns the module that contains functions for working with time away type resources.
   """
   def time_away_types, do: Humaans.TimeAwayTypes
-
-  @doc """
-  Access the Custom Fields API.
-
-  Returns the module that contains functions for working with custom field resources.
-  """
-  def custom_fields, do: Humaans.CustomFields
-
-  @doc """
-  Access the Custom Values API.
-
-  Returns the module that contains functions for working with custom value resources.
-  """
-  def custom_values, do: Humaans.CustomValues
-
-  @doc """
-  Access pagination helpers.
-
-  Returns `Humaans.Pagination`, which provides `page/4` for fetching a specific
-  page and `stream/3` for lazily iterating all results.
-  """
-  def pagination, do: Humaans.Pagination
-
-  @doc """
-  Access the query builder.
-
-  Returns `Humaans.Query`, which provides `eq/3`, `in_/3`, `nin/3`, `gt/3`,
-  `gte/3`, `lt/3`, `lte/3`, `merge/2`, and `to_params/1` for building
-  filter queries.
-  """
-  def query, do: Humaans.Query
-
-  @doc """
-  Access the current user's profile.
-
-  Returns `Humaans.Me`, which exposes `get/1` for retrieving the
-  authenticated user's profile.
-  """
-  def me, do: Humaans.Me
 
   @doc """
   Access the current access token's metadata.

--- a/lib/humaans.ex
+++ b/lib/humaans.ex
@@ -249,14 +249,6 @@ defmodule Humaans do
   def pagination, do: Humaans.Pagination
 
   @doc """
-  Access webhook helpers.
-
-  Returns `Humaans.Webhooks`, which provides `verify_signature/3` for
-  verifying HMAC-SHA256 webhook signatures.
-  """
-  def webhooks, do: Humaans.Webhooks
-
-  @doc """
   Access the query builder.
 
   Returns `Humaans.Query`, which provides `eq/3`, `in_/3`, `nin/3`, `gt/3`,
@@ -264,4 +256,28 @@ defmodule Humaans do
   filter queries.
   """
   def query, do: Humaans.Query
+
+  @doc """
+  Access the current user's profile.
+
+  Returns `Humaans.Me`, which exposes `get/1` for retrieving the
+  authenticated user's profile.
+  """
+  def me, do: Humaans.Me
+
+  @doc """
+  Access the current access token's metadata.
+
+  Returns `Humaans.TokenInfo`, which exposes `get/1` for retrieving
+  metadata (scopes, personId, etc.) about the current access token.
+  """
+  def token_info, do: Humaans.TokenInfo
+
+  @doc """
+  Access webhook helpers.
+
+  Returns `Humaans.Webhooks`, which provides `verify_signature/3` for
+  verifying HMAC-SHA256 webhook signatures.
+  """
+  def webhooks, do: Humaans.Webhooks
 end

--- a/lib/humaans/me.ex
+++ b/lib/humaans/me.ex
@@ -1,0 +1,27 @@
+defmodule Humaans.Me do
+  @moduledoc """
+  Singleton helper for the `/me` endpoint.
+
+  `GET /api/me` returns the profile of the authenticated user (the human
+  whose access token was used to make the request). Useful for
+  startup-time "who am I" checks before issuing scoped operations.
+
+  The response is decoded into a `Humaans.Resources.Person` struct.
+  """
+
+  alias Humaans.{Client, Resources.Person, ResponseHandler}
+
+  @doc """
+  Retrieves the authenticated user's profile.
+
+  ## Examples
+
+      client = Humaans.new(access_token: "your_access_token")
+      {:ok, %Humaans.Resources.Person{} = me} = Humaans.Me.get(client)
+  """
+  @spec get(client :: map()) :: {:ok, Person.t()} | {:error, Humaans.Error.t()}
+  def get(client) do
+    Client.get(client, "/me")
+    |> ResponseHandler.handle_resource_response(Person)
+  end
+end

--- a/lib/humaans/token_info.ex
+++ b/lib/humaans/token_info.ex
@@ -1,0 +1,33 @@
+defmodule Humaans.TokenInfo do
+  @moduledoc """
+  Singleton helper for the `/token-info` endpoint.
+
+  `GET /api/token-info` returns metadata about the access token used for
+  the request, including its scopes and capabilities. Useful for verifying
+  that a token has the permissions an integration needs before attempting
+  scoped operations.
+
+  The response is returned as a raw map of the API's JSON payload —
+  unlike resource endpoints, the shape is not modelled as a struct
+  because the field set is small and largely tooling-only.
+  """
+
+  alias Humaans.{Client, ResponseHandler}
+
+  @doc """
+  Retrieves metadata for the current access token.
+
+  ## Examples
+
+      client = Humaans.new(access_token: "your_access_token")
+      {:ok, info} = Humaans.TokenInfo.get(client)
+
+      info["scopes"]   # => ["private:read", "private:write", ...]
+      info["personId"] # => "person_abc"
+  """
+  @spec get(client :: map()) :: {:ok, map()} | {:error, Humaans.Error.t()}
+  def get(client) do
+    Client.get(client, "/token-info")
+    |> ResponseHandler.handle_response(& &1)
+  end
+end

--- a/test/humaans/me_test.exs
+++ b/test/humaans/me_test.exs
@@ -1,0 +1,47 @@
+defmodule Humaans.MeTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "tok", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "get/1" do
+    test "fetches /me and returns a Person struct", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _client, opts ->
+        assert Keyword.fetch!(opts, :method) == :get
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/me"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "person_abc",
+             "companyId" => "company_xyz",
+             "firstName" => "Jane",
+             "lastName" => "Doe",
+             "email" => "jane@example.com"
+           }
+         }}
+      end)
+
+      assert {:ok, person} = Humaans.Me.get(client)
+      assert %Humaans.Resources.Person{} = person
+      assert person.id == "person_abc"
+      assert person.first_name == "Jane"
+      assert person.last_name == "Doe"
+    end
+
+    test "surfaces 401 as a Humaans.Error", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _client, _opts ->
+        {:ok, %{status: 401, body: %{"message" => "unauthorized"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 401}} = Humaans.Me.get(client)
+    end
+  end
+end

--- a/test/humaans/token_info_test.exs
+++ b/test/humaans/token_info_test.exs
@@ -1,0 +1,46 @@
+defmodule Humaans.TokenInfoTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "tok", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "get/1" do
+    test "fetches /token-info and returns the body", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _client, opts ->
+        assert Keyword.fetch!(opts, :method) == :get
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/token-info"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "tok_abc",
+             "personId" => "person_xyz",
+             "label" => "Integration token",
+             "scopes" => ["private:read", "private:write"]
+           }
+         }}
+      end)
+
+      assert {:ok, info} = Humaans.TokenInfo.get(client)
+      assert info["id"] == "tok_abc"
+      assert info["personId"] == "person_xyz"
+      assert info["scopes"] == ["private:read", "private:write"]
+    end
+
+    test "surfaces 401 as a Humaans.Error", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _client, _opts ->
+        {:ok, %{status: 401, body: %{"message" => "unauthorized"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 401}} =
+               Humaans.TokenInfo.get(client)
+    end
+  end
+end


### PR DESCRIPTION
:tipping_hand_person: These changes add small dedicated modules for the two singleton endpoints that don't fit the CRUD macro: `GET /me` and `GET /token-info`.

## Summary

- `Humaans.Me.get/1` — returns the authenticated user's profile decoded into a `Humaans.Resources.Person`. Useful for "who am I" startup checks.
- `Humaans.TokenInfo.get/1` — returns access-token metadata (scopes, personId, label) as a raw map. Useful for verifying scopes before attempting privileged operations.
- `Humaans.me/0` and `Humaans.token_info/0` accessors keep discovery consistent with the other resource helpers.

## Test plan

- [x] `mix test` passes (4 new tests: success + 401 for each helper)
- [x] `mix credo --strict` clean
- [x] Smoke test against a real tenant — confirm `Me.get/1` returns the expected `Person` and `TokenInfo.get/1` lists the token's scopes