### PR TITLE
ci: Elixir v1.19 and Erlang/OTP v28

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,20 +60,32 @@ jobs:
 
     strategy:
       matrix:
-        elixir: ['1.15', '1.16', '1.17', '1.18']
-        otp: ['24', '25', '26', '27']
+        elixir: ['1.15', '1.16', '1.17', '1.18', '1.19']
+        otp: ['24', '25', '26', '27', '28']
         exclude:
           - elixir: '1.15'
             otp: '27'
+          - elixir: '1.15'
+            otp: '28'
           - elixir: '1.16'
             otp: '27'
+          - elixir: '1.16'
+            otp: '28'
           - elixir: '1.17'
             otp: '24'
+          - elixir: '1.17'
+            otp: '28'
           - elixir: '1.18'
             otp: '24'
-        include:
           - elixir: '1.18'
-            otp: '27'
+            otp: '28'
+          - elixir: '1.19'
+            otp: '24'
+          - elixir: '1.19'
+            otp: '25'
+        include:
+          - elixir: '1.19'
+            otp: '28'
             lint: true
             name: 'Linting'
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.18-otp-27
-erlang 27.2
+elixir 1.19-otp-28
+erlang 28.5


### PR DESCRIPTION
💁 These changes update the development versions of Elixir and Erlang/OTP to 1.19 and 28, as well as adding these versions to the continuous integration build matrix used for testing.