### PR TITLE
feat(companies): add retrieve/2, deprecate get/2

### DIFF
--- a/lib/humaans/companies.ex
+++ b/lib/humaans/companies.ex
@@ -8,31 +8,14 @@ defmodule Humaans.Companies do
   use Humaans.Resource,
     path: "/companies",
     struct: Humaans.Resources.Company,
-    actions: [:list, :update]
+    actions: [:list, :retrieve, :update]
 
-  alias Humaans.{Client, Resources.Company, ResponseHandler}
+  alias Humaans.Resources.Company
 
   @type list_response :: {:ok, [%Company{}]} | {:error, Humaans.Error.t()}
   @type response :: {:ok, %Company{}} | {:error, Humaans.Error.t()}
 
-  @doc """
-  Retrieves a specific company by ID.
-
-  ## Parameters
-
-    * `client` - Client map created with `Humaans.new/1`
-    * `id` - String ID of the company to retrieve
-
-  ## Examples
-
-      client = Humaans.new(access_token: "your_access_token")
-
-      {:ok, company} = Humaans.Companies.get(client, "company_id")
-
-  """
+  @deprecated "Use Humaans.Companies.retrieve/2 instead"
   @spec get(client :: map(), id :: String.t()) :: response()
-  def get(client, id) do
-    Client.get(client, "/companies/#{id}")
-    |> ResponseHandler.handle_resource_response(Company)
-  end
+  def get(client, id), do: retrieve(client, id)
 end

--- a/test/humaans/companies_test.exs
+++ b/test/humaans/companies_test.exs
@@ -138,8 +138,9 @@ defmodule Humaans.CompaniesTest do
          }}
       end)
 
-      assert {:ok, %Humaans.Resources.Company{id: "uoWtfpDIMI2IZ8doGK7kkCwS"}} =
-               apply(Humaans.Companies, :get, [client, "123"])
+      # credo:disable-for-next-line Credo.Check.Refactor.Apply
+      result = apply(Humaans.Companies, :get, [client, "123"])
+      assert {:ok, %Humaans.Resources.Company{id: "uoWtfpDIMI2IZ8doGK7kkCwS"}} = result
     end
   end
 

--- a/test/humaans/companies_test.exs
+++ b/test/humaans/companies_test.exs
@@ -81,7 +81,7 @@ defmodule Humaans.CompaniesTest do
     end
   end
 
-  describe "retrieve/1" do
+  describe "retrieve/2" do
     test "retrieves a company", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
@@ -107,7 +107,7 @@ defmodule Humaans.CompaniesTest do
          }}
       end)
 
-      assert {:ok, response} = Humaans.Companies.get(client, "123")
+      assert {:ok, response} = Humaans.Companies.retrieve(client, "123")
       assert response.id == "uoWtfpDIMI2IZ8doGK7kkCwS"
       assert response.name == "Acme"
       assert response.domains == []
@@ -118,6 +118,28 @@ defmodule Humaans.CompaniesTest do
       assert response.is_timesheet_enabled == true
       assert response.created_at == ~U[2020-01-28 08:44:42.000Z]
       assert response.updated_at == ~U[2020-01-29 14:52:21.000Z]
+    end
+  end
+
+  describe "get/2 (deprecated)" do
+    test "delegates to retrieve/2", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/companies/123"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "uoWtfpDIMI2IZ8doGK7kkCwS",
+             "name" => "Acme"
+           }
+         }}
+      end)
+
+      assert {:ok, %Humaans.Resources.Company{id: "uoWtfpDIMI2IZ8doGK7kkCwS"}} =
+               Humaans.Companies.get(client, "123")
     end
   end
 

--- a/test/humaans/companies_test.exs
+++ b/test/humaans/companies_test.exs
@@ -139,7 +139,7 @@ defmodule Humaans.CompaniesTest do
       end)
 
       assert {:ok, %Humaans.Resources.Company{id: "uoWtfpDIMI2IZ8doGK7kkCwS"}} =
-               Humaans.Companies.get(client, "123")
+               apply(Humaans.Companies, :get, [client, "123"])
     end
   end
 


### PR DESCRIPTION
:tipping_hand_person: These changes normalise `Humaans.Companies` onto the standard CRUD macro by adding `:retrieve` to the generated actions list. The custom `get/2` now delegates to `retrieve/2` and is marked `@deprecated`.

## Summary

- Add `:retrieve` to `Humaans.Companies`'s `use Humaans.Resource` actions list — the macro now generates `retrieve/2`, removing the hand-rolled implementation
- Keep `get/2` as a deprecated alias that delegates to `retrieve/2` for backwards compatibility
- Update tests: rename `retrieve/1` describe block to `retrieve/2` and add a small test asserting `get/2` still works

## Test plan

- [x] `mix test test/humaans/companies_test.exs` passes (including the new deprecated-alias test)
- [x] `mix test` full suite still passes
- [x] `mix credo` clean
- [x] Compile shows the deprecation warning when calling `Humaans.Companies.get/2`