### PR TITLE
feat(time-away): add Time Away family CRUD resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ The default HTTP client retries transient failures (status 408, 429, 500, 502, 5
 - `Humaans.Compensations` - Work with compensation resources
 - `Humaans.TimesheetEntries` - Work with timesheet entry resources
 - `Humaans.TimesheetSubmissions` - Work with timesheet submission resources
+- `Humaans.TimeAway` - Work with time away resources
+- `Humaans.TimeAwayAllocations` - Work with time away allocation resources
+- `Humaans.TimeAwayAdjustments` - Work with time away adjustment resources
+- `Humaans.TimeAwayPolicies` - Work with time away policy resources
+- `Humaans.TimeAwayTypes` - Work with time away type resources
 
 ## Development
 

--- a/lib/humaans.ex
+++ b/lib/humaans.ex
@@ -192,6 +192,41 @@ defmodule Humaans do
   def timesheet_submissions, do: Humaans.TimesheetSubmissions
 
   @doc """
+  Access the Time Away API.
+
+  Returns the module that contains functions for working with time away resources.
+  """
+  def time_away, do: Humaans.TimeAway
+
+  @doc """
+  Access the Time Away Allocations API.
+
+  Returns the module that contains functions for working with time away allocation resources.
+  """
+  def time_away_allocations, do: Humaans.TimeAwayAllocations
+
+  @doc """
+  Access the Time Away Adjustments API.
+
+  Returns the module that contains functions for working with time away adjustment resources.
+  """
+  def time_away_adjustments, do: Humaans.TimeAwayAdjustments
+
+  @doc """
+  Access the Time Away Policies API.
+
+  Returns the module that contains functions for working with time away policy resources.
+  """
+  def time_away_policies, do: Humaans.TimeAwayPolicies
+
+  @doc """
+  Access the Time Away Types API.
+
+  Returns the module that contains functions for working with time away type resources.
+  """
+  def time_away_types, do: Humaans.TimeAwayTypes
+
+  @doc """
   Access pagination helpers.
 
   Returns `Humaans.Pagination`, which provides `page/4` for fetching a specific

--- a/lib/humaans/resources/time_away.ex
+++ b/lib/humaans/resources/time_away.ex
@@ -1,0 +1,46 @@
+defmodule Humaans.Resources.TimeAway do
+  @moduledoc """
+  Representation of a Time Away resource.
+  """
+
+  defstruct [
+    :id,
+    :person_id,
+    :time_away_type_id,
+    :start_date,
+    :end_date,
+    :reason,
+    :notes,
+    :status,
+    :approved_by,
+    :created_at,
+    :updated_at
+  ]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_date(:start_date)
+    |> parse_date(:end_date)
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          person_id: binary | nil,
+          time_away_type_id: binary | nil,
+          start_date: Date.t() | nil,
+          end_date: Date.t() | nil,
+          reason: binary | nil,
+          notes: binary | nil,
+          status: binary | nil,
+          approved_by: binary | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/resources/time_away_adjustment.ex
+++ b/lib/humaans/resources/time_away_adjustment.ex
@@ -1,0 +1,36 @@
+defmodule Humaans.Resources.TimeAwayAdjustment do
+  @moduledoc """
+  Representation of a Time Away Adjustment resource.
+  """
+
+  defstruct [
+    :id,
+    :person_id,
+    :time_away_allocation_id,
+    :amount,
+    :note,
+    :created_at,
+    :updated_at
+  ]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          person_id: binary | nil,
+          time_away_allocation_id: binary | nil,
+          amount: number | nil,
+          note: binary | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/resources/time_away_allocation.ex
+++ b/lib/humaans/resources/time_away_allocation.ex
@@ -1,0 +1,44 @@
+defmodule Humaans.Resources.TimeAwayAllocation do
+  @moduledoc """
+  Representation of a Time Away Allocation resource.
+  """
+
+  defstruct [
+    :id,
+    :person_id,
+    :time_away_type_id,
+    :time_away_policy_id,
+    :amount,
+    :unit,
+    :start_date,
+    :end_date,
+    :created_at,
+    :updated_at
+  ]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_date(:start_date)
+    |> parse_date(:end_date)
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          person_id: binary | nil,
+          time_away_type_id: binary | nil,
+          time_away_policy_id: binary | nil,
+          amount: number | nil,
+          unit: binary | nil,
+          start_date: Date.t() | nil,
+          end_date: Date.t() | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/resources/time_away_policy.ex
+++ b/lib/humaans/resources/time_away_policy.ex
@@ -1,0 +1,26 @@
+defmodule Humaans.Resources.TimeAwayPolicy do
+  @moduledoc """
+  Representation of a Time Away Policy resource.
+  """
+
+  defstruct [:id, :company_id, :name, :created_at, :updated_at]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          company_id: binary | nil,
+          name: binary | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/resources/time_away_type.ex
+++ b/lib/humaans/resources/time_away_type.ex
@@ -1,0 +1,26 @@
+defmodule Humaans.Resources.TimeAwayType do
+  @moduledoc """
+  Representation of a Time Away Type resource.
+  """
+
+  defstruct [:id, :company_id, :name, :created_at, :updated_at]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          company_id: binary | nil,
+          name: binary | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/time_away.ex
+++ b/lib/humaans/time_away.ex
@@ -1,0 +1,19 @@
+defmodule Humaans.TimeAway do
+  @moduledoc """
+  This module provides functions for managing time away resources in the
+  Humaans API.
+  """
+
+  use Humaans.Resource,
+    path: "/time-away",
+    struct: Humaans.Resources.TimeAway,
+    doc_params: [
+      create:
+        ~s(%{personId: "person_abc", timeAwayTypeId: "type_abc", startDate: "2025-01-01", endDate: "2025-01-05"}),
+      update: ~s(%{notes: "Updated note"})
+    ]
+
+  @type delete_response :: {:ok, %{id: String.t(), deleted: bool()}} | {:error, Humaans.Error.t()}
+  @type list_response :: {:ok, [%Humaans.Resources.TimeAway{}]} | {:error, Humaans.Error.t()}
+  @type response :: {:ok, %Humaans.Resources.TimeAway{}} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/time_away_adjustments.ex
+++ b/lib/humaans/time_away_adjustments.ex
@@ -1,0 +1,20 @@
+defmodule Humaans.TimeAwayAdjustments do
+  @moduledoc """
+  This module provides functions for managing time away adjustment resources
+  in the Humaans API.
+  """
+
+  use Humaans.Resource,
+    path: "/time-away-adjustments",
+    struct: Humaans.Resources.TimeAwayAdjustment,
+    doc_params: [
+      create:
+        ~s(%{personId: "person_abc", timeAwayAllocationId: "allocation_abc", amount: 1.5, note: "Carry-over"}),
+      update: ~s(%{note: "Updated note"})
+    ]
+
+  @type delete_response :: {:ok, %{id: String.t(), deleted: bool()}} | {:error, Humaans.Error.t()}
+  @type list_response ::
+          {:ok, [%Humaans.Resources.TimeAwayAdjustment{}]} | {:error, Humaans.Error.t()}
+  @type response :: {:ok, %Humaans.Resources.TimeAwayAdjustment{}} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/time_away_allocations.ex
+++ b/lib/humaans/time_away_allocations.ex
@@ -1,0 +1,20 @@
+defmodule Humaans.TimeAwayAllocations do
+  @moduledoc """
+  This module provides functions for managing time away allocation resources
+  in the Humaans API.
+  """
+
+  use Humaans.Resource,
+    path: "/time-away-allocations",
+    struct: Humaans.Resources.TimeAwayAllocation,
+    doc_params: [
+      create:
+        ~s(%{personId: "person_abc", timeAwayTypeId: "type_abc", timeAwayPolicyId: "policy_abc", amount: 25, unit: "days", startDate: "2025-01-01"}),
+      update: ~s(%{amount: 30})
+    ]
+
+  @type delete_response :: {:ok, %{id: String.t(), deleted: bool()}} | {:error, Humaans.Error.t()}
+  @type list_response ::
+          {:ok, [%Humaans.Resources.TimeAwayAllocation{}]} | {:error, Humaans.Error.t()}
+  @type response :: {:ok, %Humaans.Resources.TimeAwayAllocation{}} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/time_away_policies.ex
+++ b/lib/humaans/time_away_policies.ex
@@ -1,0 +1,19 @@
+defmodule Humaans.TimeAwayPolicies do
+  @moduledoc """
+  This module provides functions for managing time away policy resources in
+  the Humaans API.
+  """
+
+  use Humaans.Resource,
+    path: "/time-away-policies",
+    struct: Humaans.Resources.TimeAwayPolicy,
+    doc_params: [
+      create: ~s(%{name: "UK Holiday Policy"}),
+      update: ~s(%{name: "Updated Holiday Policy"})
+    ]
+
+  @type delete_response :: {:ok, %{id: String.t(), deleted: bool()}} | {:error, Humaans.Error.t()}
+  @type list_response ::
+          {:ok, [%Humaans.Resources.TimeAwayPolicy{}]} | {:error, Humaans.Error.t()}
+  @type response :: {:ok, %Humaans.Resources.TimeAwayPolicy{}} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/time_away_types.ex
+++ b/lib/humaans/time_away_types.ex
@@ -1,0 +1,19 @@
+defmodule Humaans.TimeAwayTypes do
+  @moduledoc """
+  This module provides functions for managing time away type resources in the
+  Humaans API.
+  """
+
+  use Humaans.Resource,
+    path: "/time-away-types",
+    struct: Humaans.Resources.TimeAwayType,
+    doc_params: [
+      create: ~s(%{name: "Holiday"}),
+      update: ~s(%{name: "Annual Leave"})
+    ]
+
+  @type delete_response :: {:ok, %{id: String.t(), deleted: bool()}} | {:error, Humaans.Error.t()}
+  @type list_response ::
+          {:ok, [%Humaans.Resources.TimeAwayType{}]} | {:error, Humaans.Error.t()}
+  @type response :: {:ok, %Humaans.Resources.TimeAwayType{}} | {:error, Humaans.Error.t()}
+end

--- a/test/humaans/time_away_adjustments_test.exs
+++ b/test/humaans/time_away_adjustments_test.exs
@@ -16,6 +16,7 @@ defmodule Humaans.TimeAwayAdjustmentsTest do
     test "returns a list of time away adjustments", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :get
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/time-away-adjustments"
 
@@ -84,6 +85,7 @@ defmodule Humaans.TimeAwayAdjustmentsTest do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
         assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :post
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/time-away-adjustments"
 
@@ -100,6 +102,7 @@ defmodule Humaans.TimeAwayAdjustmentsTest do
     test "retrieves a time away adjustment", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :get
 
         assert Keyword.fetch!(opts, :url) ==
@@ -133,6 +136,7 @@ defmodule Humaans.TimeAwayAdjustmentsTest do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
         assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :patch
 
         assert Keyword.fetch!(opts, :url) ==
@@ -160,6 +164,7 @@ defmodule Humaans.TimeAwayAdjustmentsTest do
     test "deletes a time away adjustment", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :delete
 
         assert Keyword.fetch!(opts, :url) ==

--- a/test/humaans/time_away_adjustments_test.exs
+++ b/test/humaans/time_away_adjustments_test.exs
@@ -1,0 +1,175 @@
+defmodule Humaans.TimeAwayAdjustmentsTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.TimeAwayAdjustments
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "list/1" do
+    test "returns a list of time away adjustments", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/time-away-adjustments"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "total" => 1,
+             "limit" => 100,
+             "skip" => 0,
+             "data" => [
+               %{
+                 "id" => "adj_abc",
+                 "personId" => "person_abc",
+                 "timeAwayAllocationId" => "alloc_abc",
+                 "amount" => 1.5,
+                 "note" => "Carry-over from last year",
+                 "createdAt" => "2025-01-01T08:44:42.000Z",
+                 "updatedAt" => "2025-01-01T14:52:21.000Z"
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, [response]} = Humaans.TimeAwayAdjustments.list(client)
+      assert response.id == "adj_abc"
+      assert response.person_id == "person_abc"
+      assert response.time_away_allocation_id == "alloc_abc"
+      assert response.amount == 1.5
+      assert response.note == "Carry-over from last year"
+      assert response.created_at == ~U[2025-01-01 08:44:42.000Z]
+      assert response.updated_at == ~U[2025-01-01 14:52:21.000Z]
+    end
+
+    test "returns error when resource is not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.TimeAwayAdjustments.list(client)
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:error, "boom"}
+      end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.TimeAwayAdjustments.list(client)
+    end
+  end
+
+  describe "create/2" do
+    test "creates a time away adjustment", %{client: client} do
+      params = %{
+        "personId" => "person_abc",
+        "timeAwayAllocationId" => "alloc_abc",
+        "amount" => 1.5,
+        "note" => "Bonus day"
+      }
+
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :method) == :post
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/time-away-adjustments"
+
+        {:ok, %{status: 201, body: Map.put(params, "id", "adj_new")}}
+      end)
+
+      assert {:ok, response} = Humaans.TimeAwayAdjustments.create(client, params)
+      assert response.id == "adj_new"
+      assert response.amount == 1.5
+    end
+  end
+
+  describe "retrieve/2" do
+    test "retrieves a time away adjustment", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/time-away-adjustments/adj_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "adj_abc",
+             "personId" => "person_abc",
+             "timeAwayAllocationId" => "alloc_abc",
+             "amount" => 1.5,
+             "note" => nil,
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-01T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.TimeAwayAdjustments.retrieve(client, "adj_abc")
+      assert response.id == "adj_abc"
+      assert response.note == nil
+    end
+  end
+
+  describe "update/3" do
+    test "updates a time away adjustment", %{client: client} do
+      params = %{"note" => "Updated note"}
+
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :method) == :patch
+
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/time-away-adjustments/adj_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "adj_abc",
+             "amount" => 1.5,
+             "note" => "Updated note",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-02T08:44:42.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.TimeAwayAdjustments.update(client, "adj_abc", params)
+      assert response.note == "Updated note"
+    end
+  end
+
+  describe "delete/2" do
+    test "deletes a time away adjustment", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :delete
+
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/time-away-adjustments/adj_abc"
+
+        {:ok, %{status: 200, body: %{"id" => "adj_abc", "deleted" => true}}}
+      end)
+
+      assert {:ok, %{id: "adj_abc", deleted: true}} =
+               Humaans.TimeAwayAdjustments.delete(client, "adj_abc")
+    end
+  end
+end

--- a/test/humaans/time_away_allocations_test.exs
+++ b/test/humaans/time_away_allocations_test.exs
@@ -16,6 +16,7 @@ defmodule Humaans.TimeAwayAllocationsTest do
     test "returns a list of time away allocations", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :get
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/time-away-allocations"
 
@@ -92,6 +93,7 @@ defmodule Humaans.TimeAwayAllocationsTest do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
         assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :post
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/time-away-allocations"
 
@@ -109,6 +111,7 @@ defmodule Humaans.TimeAwayAllocationsTest do
     test "retrieves a time away allocation", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :get
 
         assert Keyword.fetch!(opts, :url) ==
@@ -145,6 +148,7 @@ defmodule Humaans.TimeAwayAllocationsTest do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
         assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :patch
 
         assert Keyword.fetch!(opts, :url) ==
@@ -172,6 +176,7 @@ defmodule Humaans.TimeAwayAllocationsTest do
     test "deletes a time away allocation", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :delete
 
         assert Keyword.fetch!(opts, :url) ==

--- a/test/humaans/time_away_allocations_test.exs
+++ b/test/humaans/time_away_allocations_test.exs
@@ -1,0 +1,187 @@
+defmodule Humaans.TimeAwayAllocationsTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.TimeAwayAllocations
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "list/1" do
+    test "returns a list of time away allocations", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/time-away-allocations"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "total" => 1,
+             "limit" => 100,
+             "skip" => 0,
+             "data" => [
+               %{
+                 "id" => "alloc_abc",
+                 "personId" => "person_abc",
+                 "timeAwayTypeId" => "type_abc",
+                 "timeAwayPolicyId" => "policy_abc",
+                 "amount" => 25,
+                 "unit" => "days",
+                 "startDate" => "2025-01-01",
+                 "endDate" => "2025-12-31",
+                 "createdAt" => "2025-01-01T08:44:42.000Z",
+                 "updatedAt" => "2025-01-01T14:52:21.000Z"
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, [response]} = Humaans.TimeAwayAllocations.list(client)
+      assert response.id == "alloc_abc"
+      assert response.person_id == "person_abc"
+      assert response.time_away_type_id == "type_abc"
+      assert response.time_away_policy_id == "policy_abc"
+      assert response.amount == 25
+      assert response.unit == "days"
+      assert response.start_date == ~D[2025-01-01]
+      assert response.end_date == ~D[2025-12-31]
+      assert response.created_at == ~U[2025-01-01 08:44:42.000Z]
+      assert response.updated_at == ~U[2025-01-01 14:52:21.000Z]
+    end
+
+    test "returns error when resource is not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.TimeAwayAllocations.list(client)
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:error, "boom"}
+      end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.TimeAwayAllocations.list(client)
+    end
+  end
+
+  describe "create/2" do
+    test "creates a time away allocation", %{client: client} do
+      params = %{
+        "personId" => "person_abc",
+        "timeAwayTypeId" => "type_abc",
+        "timeAwayPolicyId" => "policy_abc",
+        "amount" => 25,
+        "unit" => "days",
+        "startDate" => "2025-01-01"
+      }
+
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :method) == :post
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/time-away-allocations"
+
+        {:ok, %{status: 201, body: Map.put(params, "id", "alloc_new")}}
+      end)
+
+      assert {:ok, response} = Humaans.TimeAwayAllocations.create(client, params)
+      assert response.id == "alloc_new"
+      assert response.amount == 25
+      assert response.unit == "days"
+    end
+  end
+
+  describe "retrieve/2" do
+    test "retrieves a time away allocation", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/time-away-allocations/alloc_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "alloc_abc",
+             "personId" => "person_abc",
+             "timeAwayTypeId" => "type_abc",
+             "timeAwayPolicyId" => "policy_abc",
+             "amount" => 25,
+             "unit" => "days",
+             "startDate" => "2025-01-01",
+             "endDate" => nil,
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-01T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.TimeAwayAllocations.retrieve(client, "alloc_abc")
+      assert response.id == "alloc_abc"
+      assert response.end_date == nil
+    end
+  end
+
+  describe "update/3" do
+    test "updates a time away allocation", %{client: client} do
+      params = %{"amount" => 30}
+
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :method) == :patch
+
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/time-away-allocations/alloc_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "alloc_abc",
+             "amount" => 30,
+             "unit" => "days",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-02T08:44:42.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.TimeAwayAllocations.update(client, "alloc_abc", params)
+      assert response.amount == 30
+    end
+  end
+
+  describe "delete/2" do
+    test "deletes a time away allocation", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :delete
+
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/time-away-allocations/alloc_abc"
+
+        {:ok, %{status: 200, body: %{"id" => "alloc_abc", "deleted" => true}}}
+      end)
+
+      assert {:ok, %{id: "alloc_abc", deleted: true}} =
+               Humaans.TimeAwayAllocations.delete(client, "alloc_abc")
+    end
+  end
+end

--- a/test/humaans/time_away_policies_test.exs
+++ b/test/humaans/time_away_policies_test.exs
@@ -16,6 +16,7 @@ defmodule Humaans.TimeAwayPoliciesTest do
     test "returns a list of time away policies", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :get
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/time-away-policies"
 
@@ -75,6 +76,7 @@ defmodule Humaans.TimeAwayPoliciesTest do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
         assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :post
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/time-away-policies"
 
@@ -91,6 +93,7 @@ defmodule Humaans.TimeAwayPoliciesTest do
     test "retrieves a time away policy", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :get
 
         assert Keyword.fetch!(opts, :url) ==
@@ -121,6 +124,7 @@ defmodule Humaans.TimeAwayPoliciesTest do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
         assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :patch
 
         assert Keyword.fetch!(opts, :url) ==
@@ -148,6 +152,7 @@ defmodule Humaans.TimeAwayPoliciesTest do
     test "deletes a time away policy", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :delete
 
         assert Keyword.fetch!(opts, :url) ==

--- a/test/humaans/time_away_policies_test.exs
+++ b/test/humaans/time_away_policies_test.exs
@@ -1,0 +1,163 @@
+defmodule Humaans.TimeAwayPoliciesTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.TimeAwayPolicies
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "list/1" do
+    test "returns a list of time away policies", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/time-away-policies"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "total" => 1,
+             "limit" => 100,
+             "skip" => 0,
+             "data" => [
+               %{
+                 "id" => "policy_abc",
+                 "companyId" => "company_abc",
+                 "name" => "UK Holiday Policy",
+                 "createdAt" => "2025-01-01T08:44:42.000Z",
+                 "updatedAt" => "2025-01-01T14:52:21.000Z"
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, [response]} = Humaans.TimeAwayPolicies.list(client)
+      assert response.id == "policy_abc"
+      assert response.company_id == "company_abc"
+      assert response.name == "UK Holiday Policy"
+      assert response.created_at == ~U[2025-01-01 08:44:42.000Z]
+      assert response.updated_at == ~U[2025-01-01 14:52:21.000Z]
+    end
+
+    test "returns error when resource is not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.TimeAwayPolicies.list(client)
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:error, "boom"}
+      end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.TimeAwayPolicies.list(client)
+    end
+  end
+
+  describe "create/2" do
+    test "creates a time away policy", %{client: client} do
+      params = %{"name" => "UK Holiday Policy"}
+
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :method) == :post
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/time-away-policies"
+
+        {:ok, %{status: 201, body: Map.put(params, "id", "policy_new")}}
+      end)
+
+      assert {:ok, response} = Humaans.TimeAwayPolicies.create(client, params)
+      assert response.id == "policy_new"
+      assert response.name == "UK Holiday Policy"
+    end
+  end
+
+  describe "retrieve/2" do
+    test "retrieves a time away policy", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/time-away-policies/policy_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "policy_abc",
+             "companyId" => "company_abc",
+             "name" => "UK Holiday Policy",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-01T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.TimeAwayPolicies.retrieve(client, "policy_abc")
+      assert response.name == "UK Holiday Policy"
+    end
+  end
+
+  describe "update/3" do
+    test "updates a time away policy", %{client: client} do
+      params = %{"name" => "Updated Holiday Policy"}
+
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :method) == :patch
+
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/time-away-policies/policy_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "policy_abc",
+             "companyId" => "company_abc",
+             "name" => "Updated Holiday Policy",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-02T08:44:42.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.TimeAwayPolicies.update(client, "policy_abc", params)
+      assert response.name == "Updated Holiday Policy"
+    end
+  end
+
+  describe "delete/2" do
+    test "deletes a time away policy", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :delete
+
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/time-away-policies/policy_abc"
+
+        {:ok, %{status: 200, body: %{"id" => "policy_abc", "deleted" => true}}}
+      end)
+
+      assert {:ok, %{id: "policy_abc", deleted: true}} =
+               Humaans.TimeAwayPolicies.delete(client, "policy_abc")
+    end
+  end
+end

--- a/test/humaans/time_away_test.exs
+++ b/test/humaans/time_away_test.exs
@@ -93,6 +93,7 @@ defmodule Humaans.TimeAwayTest do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
         assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :post
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/time-away"
 
@@ -110,6 +111,7 @@ defmodule Humaans.TimeAwayTest do
     test "retrieves a time away record", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :get
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/time-away/ta_abc"
 
@@ -142,6 +144,7 @@ defmodule Humaans.TimeAwayTest do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
         assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :patch
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/time-away/ta_abc"
 
@@ -171,6 +174,7 @@ defmodule Humaans.TimeAwayTest do
     test "deletes a time away record", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :delete
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/time-away/ta_abc"
 

--- a/test/humaans/time_away_test.exs
+++ b/test/humaans/time_away_test.exs
@@ -1,0 +1,183 @@
+defmodule Humaans.TimeAwayTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.TimeAway
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "list/1" do
+    test "returns a list of time away records", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
+        assert Keyword.fetch!(opts, :method) == :get
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/time-away"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "total" => 1,
+             "limit" => 100,
+             "skip" => 0,
+             "data" => [
+               %{
+                 "id" => "ta_abc",
+                 "personId" => "person_abc",
+                 "timeAwayTypeId" => "type_abc",
+                 "startDate" => "2025-01-01",
+                 "endDate" => "2025-01-05",
+                 "reason" => "Vacation",
+                 "notes" => "Annual holiday",
+                 "status" => "approved",
+                 "approvedBy" => "manager_abc",
+                 "createdAt" => "2025-01-01T08:44:42.000Z",
+                 "updatedAt" => "2025-01-01T14:52:21.000Z"
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, [response]} = Humaans.TimeAway.list(client)
+      assert response.id == "ta_abc"
+      assert response.person_id == "person_abc"
+      assert response.time_away_type_id == "type_abc"
+      assert response.start_date == ~D[2025-01-01]
+      assert response.end_date == ~D[2025-01-05]
+      assert response.reason == "Vacation"
+      assert response.notes == "Annual holiday"
+      assert response.status == "approved"
+      assert response.approved_by == "manager_abc"
+      assert response.created_at == ~U[2025-01-01 08:44:42.000Z]
+      assert response.updated_at == ~U[2025-01-01 14:52:21.000Z]
+    end
+
+    test "returns error when resource is not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.TimeAway.list(client)
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:error, "boom"}
+      end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.TimeAway.list(client)
+    end
+  end
+
+  describe "create/2" do
+    test "creates a time away record", %{client: client} do
+      params = %{
+        "personId" => "person_abc",
+        "timeAwayTypeId" => "type_abc",
+        "startDate" => "2025-01-01",
+        "endDate" => "2025-01-05"
+      }
+
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :method) == :post
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/time-away"
+
+        {:ok, %{status: 201, body: Map.put(params, "id", "ta_new")}}
+      end)
+
+      assert {:ok, response} = Humaans.TimeAway.create(client, params)
+      assert response.id == "ta_new"
+      assert response.start_date == ~D[2025-01-01]
+      assert response.end_date == ~D[2025-01-05]
+    end
+  end
+
+  describe "retrieve/2" do
+    test "retrieves a time away record", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/time-away/ta_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "ta_abc",
+             "personId" => "person_abc",
+             "timeAwayTypeId" => "type_abc",
+             "startDate" => "2025-01-01",
+             "endDate" => "2025-01-05",
+             "status" => "approved",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-01T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.TimeAway.retrieve(client, "ta_abc")
+      assert response.id == "ta_abc"
+      assert response.status == "approved"
+    end
+  end
+
+  describe "update/3" do
+    test "updates a time away record", %{client: client} do
+      params = %{"notes" => "Updated"}
+
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :method) == :patch
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/time-away/ta_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "ta_abc",
+             "personId" => "person_abc",
+             "timeAwayTypeId" => "type_abc",
+             "startDate" => "2025-01-01",
+             "endDate" => "2025-01-05",
+             "notes" => "Updated",
+             "status" => "approved",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-02T08:44:42.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.TimeAway.update(client, "ta_abc", params)
+      assert response.notes == "Updated"
+    end
+  end
+
+  describe "delete/2" do
+    test "deletes a time away record", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :delete
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/time-away/ta_abc"
+
+        {:ok, %{status: 200, body: %{"id" => "ta_abc", "deleted" => true}}}
+      end)
+
+      assert {:ok, %{id: "ta_abc", deleted: true}} = Humaans.TimeAway.delete(client, "ta_abc")
+    end
+  end
+end

--- a/test/humaans/time_away_types_test.exs
+++ b/test/humaans/time_away_types_test.exs
@@ -16,6 +16,7 @@ defmodule Humaans.TimeAwayTypesTest do
     test "returns a list of time away types", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :get
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/time-away-types"
 
@@ -75,6 +76,7 @@ defmodule Humaans.TimeAwayTypesTest do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
         assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :post
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/time-away-types"
 
@@ -91,6 +93,7 @@ defmodule Humaans.TimeAwayTypesTest do
     test "retrieves a time away type", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :get
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/time-away-types/type_abc"
 
@@ -119,6 +122,7 @@ defmodule Humaans.TimeAwayTypesTest do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
         assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :patch
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/time-away-types/type_abc"
 
@@ -144,6 +148,7 @@ defmodule Humaans.TimeAwayTypesTest do
     test "deletes a time away type", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :delete
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/time-away-types/type_abc"
 

--- a/test/humaans/time_away_types_test.exs
+++ b/test/humaans/time_away_types_test.exs
@@ -1,0 +1,157 @@
+defmodule Humaans.TimeAwayTypesTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.TimeAwayTypes
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "list/1" do
+    test "returns a list of time away types", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/time-away-types"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "total" => 1,
+             "limit" => 100,
+             "skip" => 0,
+             "data" => [
+               %{
+                 "id" => "type_abc",
+                 "companyId" => "company_abc",
+                 "name" => "Holiday",
+                 "createdAt" => "2025-01-01T08:44:42.000Z",
+                 "updatedAt" => "2025-01-01T14:52:21.000Z"
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, [response]} = Humaans.TimeAwayTypes.list(client)
+      assert response.id == "type_abc"
+      assert response.company_id == "company_abc"
+      assert response.name == "Holiday"
+      assert response.created_at == ~U[2025-01-01 08:44:42.000Z]
+      assert response.updated_at == ~U[2025-01-01 14:52:21.000Z]
+    end
+
+    test "returns error when resource is not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.TimeAwayTypes.list(client)
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:error, "boom"}
+      end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.TimeAwayTypes.list(client)
+    end
+  end
+
+  describe "create/2" do
+    test "creates a time away type", %{client: client} do
+      params = %{"name" => "Holiday"}
+
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :method) == :post
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/time-away-types"
+
+        {:ok, %{status: 201, body: Map.put(params, "id", "type_new")}}
+      end)
+
+      assert {:ok, response} = Humaans.TimeAwayTypes.create(client, params)
+      assert response.id == "type_new"
+      assert response.name == "Holiday"
+    end
+  end
+
+  describe "retrieve/2" do
+    test "retrieves a time away type", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/time-away-types/type_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "type_abc",
+             "companyId" => "company_abc",
+             "name" => "Holiday",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-01T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.TimeAwayTypes.retrieve(client, "type_abc")
+      assert response.name == "Holiday"
+    end
+  end
+
+  describe "update/3" do
+    test "updates a time away type", %{client: client} do
+      params = %{"name" => "Annual Leave"}
+
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :method) == :patch
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/time-away-types/type_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "type_abc",
+             "companyId" => "company_abc",
+             "name" => "Annual Leave",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-02T08:44:42.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.TimeAwayTypes.update(client, "type_abc", params)
+      assert response.name == "Annual Leave"
+    end
+  end
+
+  describe "delete/2" do
+    test "deletes a time away type", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :delete
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/time-away-types/type_abc"
+
+        {:ok, %{status: 200, body: %{"id" => "type_abc", "deleted" => true}}}
+      end)
+
+      assert {:ok, %{id: "type_abc", deleted: true}} =
+               Humaans.TimeAwayTypes.delete(client, "type_abc")
+    end
+  end
+end

--- a/test/humaans_test.exs
+++ b/test/humaans_test.exs
@@ -121,6 +121,26 @@ defmodule HumaansTest do
     assert Humaans.timesheet_submissions() == Humaans.TimesheetSubmissions
   end
 
+  test "time_away/0 returns the TimeAway module" do
+    assert Humaans.time_away() == Humaans.TimeAway
+  end
+
+  test "time_away_allocations/0 returns the TimeAwayAllocations module" do
+    assert Humaans.time_away_allocations() == Humaans.TimeAwayAllocations
+  end
+
+  test "time_away_adjustments/0 returns the TimeAwayAdjustments module" do
+    assert Humaans.time_away_adjustments() == Humaans.TimeAwayAdjustments
+  end
+
+  test "time_away_policies/0 returns the TimeAwayPolicies module" do
+    assert Humaans.time_away_policies() == Humaans.TimeAwayPolicies
+  end
+
+  test "time_away_types/0 returns the TimeAwayTypes module" do
+    assert Humaans.time_away_types() == Humaans.TimeAwayTypes
+  end
+
   test "pagination/0 returns the Pagination module" do
     assert Humaans.pagination() == Humaans.Pagination
   end


### PR DESCRIPTION
:tipping_hand_person: These changes add full CRUD coverage for the five Time Away family resources documented at https://docs.humaans.io/api/.

## Summary

- `Humaans.TimeAway` — `/api/time-away` (the leave/PTO records themselves)
- `Humaans.TimeAwayAllocations` — `/api/time-away-allocations` (per-person quotas)
- `Humaans.TimeAwayAdjustments` — `/api/time-away-adjustments` (+/- amounts against an allocation)
- `Humaans.TimeAwayPolicies` — `/api/time-away-policies` (company-scoped policies)
- `Humaans.TimeAwayTypes` — `/api/time-away-types` (Holiday, Sickness, etc.)

Each ships as struct + module + tests using the existing `Humaans.Resource` macro (no new infrastructure). Module access helpers (`Humaans.time_away/0`, etc.) are added to `Humaans` and the README's "Available resources" list is updated.

Addresses **Group D1** (Time Away family) of the API coverage review (`~/.claude/plans/review-the-api-documentation-swirling-scroll.md`).

## Test plan

- [ ] `mix test` — 37 new tests pass alongside the existing suite
- [ ] `mix credo` clean
- [ ] `mix format --check-formatted` clean
- [ ] Spot-check the new structs against `docs.humaans.io` field schemas