### PR TITLE
feat(custom-fields): add Custom Fields and Custom Values CRUD

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ Supported operators: `eq`, `in_`, `nin`, `gt`, `gte`, `lt`, `lte`. Use `Humaans.
 - `Humaans.TimeAwayAdjustments` - Work with time away adjustment resources
 - `Humaans.TimeAwayPolicies` - Work with time away policy resources
 - `Humaans.TimeAwayTypes` - Work with time away type resources
+- `Humaans.CustomFields` - Work with custom field definitions
+- `Humaans.CustomValues` - Work with custom value records
 
 ## Development
 

--- a/lib/humaans.ex
+++ b/lib/humaans.ex
@@ -227,6 +227,20 @@ defmodule Humaans do
   def time_away_types, do: Humaans.TimeAwayTypes
 
   @doc """
+  Access the Custom Fields API.
+
+  Returns the module that contains functions for working with custom field resources.
+  """
+  def custom_fields, do: Humaans.CustomFields
+
+  @doc """
+  Access the Custom Values API.
+
+  Returns the module that contains functions for working with custom value resources.
+  """
+  def custom_values, do: Humaans.CustomValues
+
+  @doc """
   Access pagination helpers.
 
   Returns `Humaans.Pagination`, which provides `page/4` for fetching a specific

--- a/lib/humaans/custom_fields.ex
+++ b/lib/humaans/custom_fields.ex
@@ -1,0 +1,19 @@
+defmodule Humaans.CustomFields do
+  @moduledoc """
+  This module provides functions for managing custom field resources in the
+  Humaans API.
+  """
+
+  use Humaans.Resource,
+    path: "/custom-fields",
+    struct: Humaans.Resources.CustomField,
+    doc_params: [
+      create:
+        ~s(%{name: "T-shirt size", section: "basics", type: "select", config: %{choices: ["S", "M", "L"]}}),
+      update: ~s(%{name: "Shirt size"})
+    ]
+
+  @type delete_response :: {:ok, %{id: String.t(), deleted: bool()}} | {:error, Humaans.Error.t()}
+  @type list_response :: {:ok, [%Humaans.Resources.CustomField{}]} | {:error, Humaans.Error.t()}
+  @type response :: {:ok, %Humaans.Resources.CustomField{}} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/custom_values.ex
+++ b/lib/humaans/custom_values.ex
@@ -1,0 +1,18 @@
+defmodule Humaans.CustomValues do
+  @moduledoc """
+  This module provides functions for managing custom value resources in the
+  Humaans API.
+  """
+
+  use Humaans.Resource,
+    path: "/custom-values",
+    struct: Humaans.Resources.CustomValue,
+    doc_params: [
+      create: ~s(%{personId: "person_abc", customFieldId: "field_abc", value: "M"}),
+      update: ~s(%{value: "L"})
+    ]
+
+  @type delete_response :: {:ok, %{id: String.t(), deleted: bool()}} | {:error, Humaans.Error.t()}
+  @type list_response :: {:ok, [%Humaans.Resources.CustomValue{}]} | {:error, Humaans.Error.t()}
+  @type response :: {:ok, %Humaans.Resources.CustomValue{}} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/custom_values.ex
+++ b/lib/humaans/custom_values.ex
@@ -8,7 +8,7 @@ defmodule Humaans.CustomValues do
     path: "/custom-values",
     struct: Humaans.Resources.CustomValue,
     doc_params: [
-      create: ~s(%{personId: "person_abc", customFieldId: "field_abc", value: "M"}),
+      create: ~s(%{personId: "person_abc", customFieldId: "cf_abc", value: "M"}),
       update: ~s(%{value: "L"})
     ]
 

--- a/lib/humaans/resources/custom_field.ex
+++ b/lib/humaans/resources/custom_field.ex
@@ -1,0 +1,40 @@
+defmodule Humaans.Resources.CustomField do
+  @moduledoc """
+  Representation of a Custom Field resource.
+  """
+
+  defstruct [
+    :id,
+    :company_id,
+    :name,
+    :section,
+    :resource_id,
+    :type,
+    :config,
+    :created_at,
+    :updated_at
+  ]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          company_id: binary | nil,
+          name: binary | nil,
+          section: binary | nil,
+          resource_id: binary | nil,
+          type: binary | nil,
+          config: map | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/resources/custom_value.ex
+++ b/lib/humaans/resources/custom_value.ex
@@ -1,0 +1,36 @@
+defmodule Humaans.Resources.CustomValue do
+  @moduledoc """
+  Representation of a Custom Value resource.
+  """
+
+  defstruct [
+    :id,
+    :person_id,
+    :custom_field_id,
+    :resource_id,
+    :value,
+    :created_at,
+    :updated_at
+  ]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          person_id: binary | nil,
+          custom_field_id: binary | nil,
+          resource_id: binary | nil,
+          value: binary | [binary] | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/test/humaans/custom_fields_test.exs
+++ b/test/humaans/custom_fields_test.exs
@@ -112,8 +112,10 @@ defmodule Humaans.CustomFieldsTest do
            status: 200,
            body: %{
              "id" => "cf_abc",
+             "companyId" => "company_abc",
              "name" => "T-shirt size",
              "section" => "basics",
+             "resourceId" => "res_abc",
              "type" => "select",
              "config" => %{"choices" => ["S", "M", "L"]},
              "createdAt" => "2025-01-01T08:44:42.000Z",
@@ -123,7 +125,12 @@ defmodule Humaans.CustomFieldsTest do
       end)
 
       assert {:ok, response} = Humaans.CustomFields.retrieve(client, "cf_abc")
+      assert response.id == "cf_abc"
+      assert response.company_id == "company_abc"
       assert response.name == "T-shirt size"
+      assert response.resource_id == "res_abc"
+      assert response.created_at == ~U[2025-01-01 08:44:42.000Z]
+      assert response.updated_at == ~U[2025-01-01 14:52:21.000Z]
     end
   end
 
@@ -142,8 +149,10 @@ defmodule Humaans.CustomFieldsTest do
            status: 200,
            body: %{
              "id" => "cf_abc",
+             "companyId" => "company_abc",
              "name" => "Shirt size",
              "section" => "basics",
+             "resourceId" => "res_abc",
              "type" => "select",
              "config" => %{"choices" => ["S", "M", "L"]},
              "createdAt" => "2025-01-01T08:44:42.000Z",
@@ -153,7 +162,12 @@ defmodule Humaans.CustomFieldsTest do
       end)
 
       assert {:ok, response} = Humaans.CustomFields.update(client, "cf_abc", params)
+      assert response.id == "cf_abc"
+      assert response.company_id == "company_abc"
       assert response.name == "Shirt size"
+      assert response.resource_id == "res_abc"
+      assert response.created_at == ~U[2025-01-01 08:44:42.000Z]
+      assert response.updated_at == ~U[2025-01-02 08:44:42.000Z]
     end
   end
 

--- a/test/humaans/custom_fields_test.exs
+++ b/test/humaans/custom_fields_test.exs
@@ -1,0 +1,174 @@
+defmodule Humaans.CustomFieldsTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.CustomFields
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "list/1" do
+    test "returns a list of custom fields", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/custom-fields"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "total" => 1,
+             "limit" => 100,
+             "skip" => 0,
+             "data" => [
+               %{
+                 "id" => "cf_abc",
+                 "companyId" => "company_abc",
+                 "name" => "T-shirt size",
+                 "section" => "basics",
+                 "resourceId" => nil,
+                 "type" => "select",
+                 "config" => %{"choices" => ["S", "M", "L"]},
+                 "createdAt" => "2025-01-01T08:44:42.000Z",
+                 "updatedAt" => "2025-01-01T14:52:21.000Z"
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, [response]} = Humaans.CustomFields.list(client)
+      assert response.id == "cf_abc"
+      assert response.company_id == "company_abc"
+      assert response.name == "T-shirt size"
+      assert response.section == "basics"
+      assert response.resource_id == nil
+      assert response.type == "select"
+      assert response.config == %{"choices" => ["S", "M", "L"]}
+      assert response.created_at == ~U[2025-01-01 08:44:42.000Z]
+      assert response.updated_at == ~U[2025-01-01 14:52:21.000Z]
+    end
+
+    test "returns error when resource is not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.CustomFields.list(client)
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:error, "boom"}
+      end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.CustomFields.list(client)
+    end
+  end
+
+  describe "create/2" do
+    test "creates a custom field", %{client: client} do
+      params = %{
+        "name" => "T-shirt size",
+        "section" => "basics",
+        "type" => "select",
+        "config" => %{"choices" => ["S", "M", "L"]}
+      }
+
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :method) == :post
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/custom-fields"
+
+        {:ok, %{status: 201, body: Map.put(params, "id", "cf_new")}}
+      end)
+
+      assert {:ok, response} = Humaans.CustomFields.create(client, params)
+      assert response.id == "cf_new"
+      assert response.type == "select"
+    end
+  end
+
+  describe "retrieve/2" do
+    test "retrieves a custom field", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/custom-fields/cf_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "cf_abc",
+             "name" => "T-shirt size",
+             "section" => "basics",
+             "type" => "select",
+             "config" => %{"choices" => ["S", "M", "L"]},
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-01T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.CustomFields.retrieve(client, "cf_abc")
+      assert response.name == "T-shirt size"
+    end
+  end
+
+  describe "update/3" do
+    test "updates a custom field", %{client: client} do
+      params = %{"name" => "Shirt size"}
+
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :method) == :patch
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/custom-fields/cf_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "cf_abc",
+             "name" => "Shirt size",
+             "section" => "basics",
+             "type" => "select",
+             "config" => %{"choices" => ["S", "M", "L"]},
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-02T08:44:42.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.CustomFields.update(client, "cf_abc", params)
+      assert response.name == "Shirt size"
+    end
+  end
+
+  describe "delete/2" do
+    test "deletes a custom field", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :delete
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/custom-fields/cf_abc"
+
+        {:ok, %{status: 200, body: %{"id" => "cf_abc", "deleted" => true}}}
+      end)
+
+      assert {:ok, %{id: "cf_abc", deleted: true}} =
+               Humaans.CustomFields.delete(client, "cf_abc")
+    end
+  end
+end

--- a/test/humaans/custom_values_test.exs
+++ b/test/humaans/custom_values_test.exs
@@ -16,6 +16,7 @@ defmodule Humaans.CustomValuesTest do
     test "returns a list of custom values", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :get
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/custom-values"
 
@@ -63,8 +64,9 @@ defmodule Humaans.CustomValuesTest do
     end
 
     test "returns error when resource is not found", %{client: client} do
-      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         {:ok, %{status: 404, body: %{"error" => "Not found"}}}
       end)
 
@@ -73,8 +75,9 @@ defmodule Humaans.CustomValuesTest do
     end
 
     test "returns error when request fails", %{client: client} do
-      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         {:error, "boom"}
       end)
 
@@ -94,6 +97,7 @@ defmodule Humaans.CustomValuesTest do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
         assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :post
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/custom-values"
 
@@ -110,6 +114,7 @@ defmodule Humaans.CustomValuesTest do
     test "retrieves a custom value", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :get
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/custom-values/cv_abc"
 
@@ -120,6 +125,7 @@ defmodule Humaans.CustomValuesTest do
              "id" => "cv_abc",
              "personId" => "person_abc",
              "customFieldId" => "cf_abc",
+             "resourceId" => "res_abc",
              "value" => "M",
              "createdAt" => "2025-01-01T08:44:42.000Z",
              "updatedAt" => "2025-01-01T14:52:21.000Z"
@@ -128,7 +134,13 @@ defmodule Humaans.CustomValuesTest do
       end)
 
       assert {:ok, response} = Humaans.CustomValues.retrieve(client, "cv_abc")
+      assert response.id == "cv_abc"
+      assert response.person_id == "person_abc"
+      assert response.custom_field_id == "cf_abc"
+      assert response.resource_id == "res_abc"
       assert response.value == "M"
+      assert response.created_at == ~U[2025-01-01 08:44:42.000Z]
+      assert response.updated_at == ~U[2025-01-01 14:52:21.000Z]
     end
   end
 
@@ -139,6 +151,7 @@ defmodule Humaans.CustomValuesTest do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
         assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :patch
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/custom-values/cv_abc"
 
@@ -147,6 +160,9 @@ defmodule Humaans.CustomValuesTest do
            status: 200,
            body: %{
              "id" => "cv_abc",
+             "personId" => "person_abc",
+             "customFieldId" => "cf_abc",
+             "resourceId" => "res_abc",
              "value" => "L",
              "createdAt" => "2025-01-01T08:44:42.000Z",
              "updatedAt" => "2025-01-02T08:44:42.000Z"
@@ -155,7 +171,13 @@ defmodule Humaans.CustomValuesTest do
       end)
 
       assert {:ok, response} = Humaans.CustomValues.update(client, "cv_abc", params)
+      assert response.id == "cv_abc"
+      assert response.person_id == "person_abc"
+      assert response.custom_field_id == "cf_abc"
+      assert response.resource_id == "res_abc"
       assert response.value == "L"
+      assert response.created_at == ~U[2025-01-01 08:44:42.000Z]
+      assert response.updated_at == ~U[2025-01-02 08:44:42.000Z]
     end
   end
 
@@ -163,6 +185,7 @@ defmodule Humaans.CustomValuesTest do
     test "deletes a custom value", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :delete
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/custom-values/cv_abc"
 

--- a/test/humaans/custom_values_test.exs
+++ b/test/humaans/custom_values_test.exs
@@ -1,0 +1,176 @@
+defmodule Humaans.CustomValuesTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.CustomValues
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "list/1" do
+    test "returns a list of custom values", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/custom-values"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "total" => 2,
+             "limit" => 100,
+             "skip" => 0,
+             "data" => [
+               %{
+                 "id" => "cv_abc",
+                 "personId" => "person_abc",
+                 "customFieldId" => "cf_abc",
+                 "resourceId" => nil,
+                 "value" => "M",
+                 "createdAt" => "2025-01-01T08:44:42.000Z",
+                 "updatedAt" => "2025-01-01T14:52:21.000Z"
+               },
+               %{
+                 "id" => "cv_def",
+                 "personId" => "person_def",
+                 "customFieldId" => "cf_multi",
+                 "resourceId" => nil,
+                 "value" => ["foo", "bar"],
+                 "createdAt" => "2025-01-01T08:44:42.000Z",
+                 "updatedAt" => "2025-01-01T14:52:21.000Z"
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, responses} = Humaans.CustomValues.list(client)
+      assert length(responses) == 2
+
+      multi = Enum.find(responses, &(&1.id == "cv_def"))
+      single = Enum.find(responses, &(&1.id == "cv_abc"))
+
+      assert single.person_id == "person_abc"
+      assert single.custom_field_id == "cf_abc"
+      assert single.value == "M"
+      assert multi.value == ["foo", "bar"]
+    end
+
+    test "returns error when resource is not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.CustomValues.list(client)
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:error, "boom"}
+      end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.CustomValues.list(client)
+    end
+  end
+
+  describe "create/2" do
+    test "creates a custom value", %{client: client} do
+      params = %{
+        "personId" => "person_abc",
+        "customFieldId" => "cf_abc",
+        "value" => "M"
+      }
+
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :method) == :post
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/custom-values"
+
+        {:ok, %{status: 201, body: Map.put(params, "id", "cv_new")}}
+      end)
+
+      assert {:ok, response} = Humaans.CustomValues.create(client, params)
+      assert response.id == "cv_new"
+      assert response.value == "M"
+    end
+  end
+
+  describe "retrieve/2" do
+    test "retrieves a custom value", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/custom-values/cv_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "cv_abc",
+             "personId" => "person_abc",
+             "customFieldId" => "cf_abc",
+             "value" => "M",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-01T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.CustomValues.retrieve(client, "cv_abc")
+      assert response.value == "M"
+    end
+  end
+
+  describe "update/3" do
+    test "updates a custom value", %{client: client} do
+      params = %{"value" => "L"}
+
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :method) == :patch
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/custom-values/cv_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "cv_abc",
+             "value" => "L",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-02T08:44:42.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.CustomValues.update(client, "cv_abc", params)
+      assert response.value == "L"
+    end
+  end
+
+  describe "delete/2" do
+    test "deletes a custom value", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :delete
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/custom-values/cv_abc"
+
+        {:ok, %{status: 200, body: %{"id" => "cv_abc", "deleted" => true}}}
+      end)
+
+      assert {:ok, %{id: "cv_abc", deleted: true}} =
+               Humaans.CustomValues.delete(client, "cv_abc")
+    end
+  end
+end


### PR DESCRIPTION
:tipping_hand_person: These changes add full CRUD coverage for Custom Fields and Custom Values, the bespoke-attribute system most Humaans tenants rely on.

## Summary

- `Humaans.CustomFields`: `/api/custom-fields` (per-company field definitions, with section/type/config)
- `Humaans.CustomValues`: `/api/custom-values` (per-person values, with `value` typed as `string | string[]`)

Both ship as struct + module + tests using the existing `Humaans.Resource` macro. Module access helpers (`Humaans.custom_fields/0`, `Humaans.custom_values/0`) are added and the README's "Available resources" list is updated.

## Test plan

- [x] `mix test` passes (16 new tests)
- [x] `mix credo` clean
- [x] `mix format --check-formatted` clean