### PR TITLE
feat(documents): add Documents, Document Types, and Document Folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,16 +123,19 @@ Supported operators: `eq`, `in_`, `nin`, `gt`, `gte`, `lt`, `lte`. Use `Humaans.
 - `Humaans.Companies` - Work with company resources
 - `Humaans.CompensationTypes` - Work with compensation type resources
 - `Humaans.Compensations` - Work with compensation resources
-- `Humaans.TimesheetEntries` - Work with timesheet entry resources
-- `Humaans.TimesheetSubmissions` - Work with timesheet submission resources
-- `Humaans.TimeAway` - Work with time away resources
-- `Humaans.TimeAwayAllocations` - Work with time away allocation resources
-- `Humaans.TimeAwayAdjustments` - Work with time away adjustment resources
-- `Humaans.TimeAwayPolicies` - Work with time away policy resources
-- `Humaans.TimeAwayTypes` - Work with time away type resources
 - `Humaans.CustomFields` - Work with custom field definitions
 - `Humaans.CustomValues` - Work with custom value records
+- `Humaans.DocumentFolders` - Work with document folder resources
+- `Humaans.DocumentTypes` - Work with document type resources
+- `Humaans.Documents` - Work with document resources
 - `Humaans.Me` - Retrieve the authenticated user's profile (`GET /me`)
+- `Humaans.TimeAwayAdjustments` - Work with time away adjustment resources
+- `Humaans.TimeAwayAllocations` - Work with time away allocation resources
+- `Humaans.TimeAwayPolicies` - Work with time away policy resources
+- `Humaans.TimeAwayTypes` - Work with time away type resources
+- `Humaans.TimeAway` - Work with time away resources
+- `Humaans.TimesheetEntries` - Work with timesheet entry resources
+- `Humaans.TimesheetSubmissions` - Work with timesheet submission resources
 - `Humaans.TokenInfo` - Retrieve metadata about the current access token (`GET /token-info`)
 
 ## Development

--- a/lib/humaans.ex
+++ b/lib/humaans.ex
@@ -185,6 +185,27 @@ defmodule Humaans do
   def custom_values, do: Humaans.CustomValues
 
   @doc """
+  Access the Documents API.
+
+  Returns the module that contains functions for working with document resources.
+  """
+  def documents, do: Humaans.Documents
+
+  @doc """
+  Access the Document Types API.
+
+  Returns the module that contains functions for working with document type resources.
+  """
+  def document_types, do: Humaans.DocumentTypes
+
+  @doc """
+  Access the Document Folders API.
+
+  Returns the module that contains functions for working with document folder resources.
+  """
+  def document_folders, do: Humaans.DocumentFolders
+
+  @doc """
   Access the current user's profile.
 
   Returns `Humaans.Me`, which exposes `get/1` for retrieving the

--- a/lib/humaans/document_folders.ex
+++ b/lib/humaans/document_folders.ex
@@ -1,0 +1,19 @@
+defmodule Humaans.DocumentFolders do
+  @moduledoc """
+  This module provides functions for managing document folder resources in the
+  Humaans API.
+  """
+
+  use Humaans.Resource,
+    path: "/document-folders",
+    struct: Humaans.Resources.DocumentFolder,
+    doc_params: [
+      create: ~s(%{name: "Onboarding"}),
+      update: ~s(%{name: "Onboarding Documents"})
+    ]
+
+  @type delete_response :: {:ok, %{id: String.t(), deleted: bool()}} | {:error, Humaans.Error.t()}
+  @type list_response ::
+          {:ok, [%Humaans.Resources.DocumentFolder{}]} | {:error, Humaans.Error.t()}
+  @type response :: {:ok, %Humaans.Resources.DocumentFolder{}} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/document_types.ex
+++ b/lib/humaans/document_types.ex
@@ -1,0 +1,18 @@
+defmodule Humaans.DocumentTypes do
+  @moduledoc """
+  This module provides functions for managing document type resources in the
+  Humaans API.  Note that document types do not support deletion.
+  """
+
+  use Humaans.Resource,
+    path: "/document-types",
+    struct: Humaans.Resources.DocumentType,
+    actions: [:list, :create, :retrieve, :update],
+    doc_params: [
+      create: ~s(%{name: "Passport"}),
+      update: ~s(%{name: "Identity Document"})
+    ]
+
+  @type list_response :: {:ok, [%Humaans.Resources.DocumentType{}]} | {:error, Humaans.Error.t()}
+  @type response :: {:ok, %Humaans.Resources.DocumentType{}} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/documents.ex
+++ b/lib/humaans/documents.ex
@@ -1,0 +1,19 @@
+defmodule Humaans.Documents do
+  @moduledoc """
+  This module provides functions for managing document resources in the
+  Humaans API.
+  """
+
+  use Humaans.Resource,
+    path: "/documents",
+    struct: Humaans.Resources.Document,
+    doc_params: [
+      create:
+        ~s(%{personId: "person_abc", documentTypeId: "type_abc", name: "Passport", link: "https://example.com/passport.pdf"}),
+      update: ~s|%{name: "Passport (renewed)"}|
+    ]
+
+  @type delete_response :: {:ok, %{id: String.t(), deleted: bool()}} | {:error, Humaans.Error.t()}
+  @type list_response :: {:ok, [%Humaans.Resources.Document{}]} | {:error, Humaans.Error.t()}
+  @type response :: {:ok, %Humaans.Resources.Document{}} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/resources/document.ex
+++ b/lib/humaans/resources/document.ex
@@ -1,0 +1,53 @@
+defmodule Humaans.Resources.Document do
+  @moduledoc """
+  Representation of a Document resource.
+  """
+
+  defstruct [
+    :id,
+    :company_id,
+    :person_id,
+    :name,
+    :document_type_id,
+    :folder_id,
+    :link,
+    :file_id,
+    :file,
+    :source,
+    :source_id,
+    :issue_date,
+    :created_by,
+    :created_at,
+    :updated_at
+  ]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_date(:issue_date)
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          company_id: binary | nil,
+          person_id: binary | nil,
+          name: binary | nil,
+          document_type_id: binary | nil,
+          folder_id: binary | nil,
+          link: binary | nil,
+          file_id: binary | nil,
+          file: map | nil,
+          source: binary | nil,
+          source_id: binary | nil,
+          issue_date: Date.t() | nil,
+          created_by: binary | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/resources/document_folder.ex
+++ b/lib/humaans/resources/document_folder.ex
@@ -1,0 +1,39 @@
+defmodule Humaans.Resources.DocumentFolder do
+  @moduledoc """
+  Representation of a Document Folder resource.
+  """
+
+  defstruct [
+    :id,
+    :company_id,
+    :name,
+    :audience,
+    :created_by,
+    :created_at,
+    :updated_at,
+    :deleted_at
+  ]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+    |> parse_datetime(:deleted_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          company_id: binary | nil,
+          name: binary | nil,
+          audience: map | nil,
+          created_by: binary | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil,
+          deleted_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/resources/document_type.ex
+++ b/lib/humaans/resources/document_type.ex
@@ -1,0 +1,26 @@
+defmodule Humaans.Resources.DocumentType do
+  @moduledoc """
+  Representation of a Document Type resource.
+  """
+
+  defstruct [:id, :company_id, :name, :created_at, :updated_at]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          company_id: binary | nil,
+          name: binary | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/test/humaans/document_folders_test.exs
+++ b/test/humaans/document_folders_test.exs
@@ -1,0 +1,167 @@
+defmodule Humaans.DocumentFoldersTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.DocumentFolders
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "list/1" do
+    test "returns a list of document folders", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/document-folders"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "total" => 1,
+             "limit" => 100,
+             "skip" => 0,
+             "data" => [
+               %{
+                 "id" => "folder_abc",
+                 "companyId" => "company_abc",
+                 "name" => "Onboarding",
+                 "audience" => %{"type" => "all", "rules" => []},
+                 "createdBy" => "person_def",
+                 "createdAt" => "2025-01-01T08:44:42.000Z",
+                 "updatedAt" => "2025-01-01T14:52:21.000Z",
+                 "deletedAt" => nil
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, [response]} = Humaans.DocumentFolders.list(client)
+      assert response.id == "folder_abc"
+      assert response.company_id == "company_abc"
+      assert response.name == "Onboarding"
+      assert response.audience == %{"type" => "all", "rules" => []}
+      assert response.created_by == "person_def"
+      assert response.created_at == ~U[2025-01-01 08:44:42.000Z]
+      assert response.deleted_at == nil
+    end
+
+    test "returns error when resource is not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.DocumentFolders.list(client)
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:error, "boom"}
+      end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.DocumentFolders.list(client)
+    end
+  end
+
+  describe "create/2" do
+    test "creates a document folder", %{client: client} do
+      params = %{"name" => "Onboarding"}
+
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :method) == :post
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/document-folders"
+
+        {:ok, %{status: 201, body: Map.put(params, "id", "folder_new")}}
+      end)
+
+      assert {:ok, response} = Humaans.DocumentFolders.create(client, params)
+      assert response.id == "folder_new"
+      assert response.name == "Onboarding"
+    end
+  end
+
+  describe "retrieve/2" do
+    test "retrieves a document folder", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/document-folders/folder_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "folder_abc",
+             "companyId" => "company_abc",
+             "name" => "Onboarding",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-01T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.DocumentFolders.retrieve(client, "folder_abc")
+      assert response.name == "Onboarding"
+    end
+  end
+
+  describe "update/3" do
+    test "updates a document folder", %{client: client} do
+      params = %{"name" => "Onboarding Documents"}
+
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :method) == :patch
+
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/document-folders/folder_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "folder_abc",
+             "name" => "Onboarding Documents",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-02T08:44:42.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.DocumentFolders.update(client, "folder_abc", params)
+      assert response.name == "Onboarding Documents"
+    end
+  end
+
+  describe "delete/2" do
+    test "deletes a document folder", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :delete
+
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/document-folders/folder_abc"
+
+        {:ok, %{status: 200, body: %{"id" => "folder_abc", "deleted" => true}}}
+      end)
+
+      assert {:ok, %{id: "folder_abc", deleted: true}} =
+               Humaans.DocumentFolders.delete(client, "folder_abc")
+    end
+  end
+end

--- a/test/humaans/document_folders_test.exs
+++ b/test/humaans/document_folders_test.exs
@@ -16,6 +16,7 @@ defmodule Humaans.DocumentFoldersTest do
     test "returns a list of document folders", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :get
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/document-folders"
 
@@ -80,6 +81,7 @@ defmodule Humaans.DocumentFoldersTest do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
         assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :post
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/document-folders"
 
@@ -96,6 +98,7 @@ defmodule Humaans.DocumentFoldersTest do
     test "retrieves a document folder", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :get
 
         assert Keyword.fetch!(opts, :url) ==
@@ -126,6 +129,7 @@ defmodule Humaans.DocumentFoldersTest do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
         assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :patch
 
         assert Keyword.fetch!(opts, :url) ==
@@ -152,6 +156,7 @@ defmodule Humaans.DocumentFoldersTest do
     test "deletes a document folder", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :delete
 
         assert Keyword.fetch!(opts, :url) ==

--- a/test/humaans/document_types_test.exs
+++ b/test/humaans/document_types_test.exs
@@ -1,0 +1,146 @@
+defmodule Humaans.DocumentTypesTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.DocumentTypes
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "list/1" do
+    test "returns a list of document types", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/document-types"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "total" => 1,
+             "limit" => 100,
+             "skip" => 0,
+             "data" => [
+               %{
+                 "id" => "type_abc",
+                 "companyId" => "company_abc",
+                 "name" => "Passport",
+                 "createdAt" => "2025-01-01T08:44:42.000Z",
+                 "updatedAt" => "2025-01-01T14:52:21.000Z"
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, [response]} = Humaans.DocumentTypes.list(client)
+      assert response.id == "type_abc"
+      assert response.company_id == "company_abc"
+      assert response.name == "Passport"
+      assert response.created_at == ~U[2025-01-01 08:44:42.000Z]
+      assert response.updated_at == ~U[2025-01-01 14:52:21.000Z]
+    end
+
+    test "returns error when resource is not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.DocumentTypes.list(client)
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:error, "boom"}
+      end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.DocumentTypes.list(client)
+    end
+  end
+
+  describe "create/2" do
+    test "creates a document type", %{client: client} do
+      params = %{"name" => "Passport"}
+
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :method) == :post
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/document-types"
+
+        {:ok, %{status: 201, body: Map.put(params, "id", "type_new")}}
+      end)
+
+      assert {:ok, response} = Humaans.DocumentTypes.create(client, params)
+      assert response.id == "type_new"
+      assert response.name == "Passport"
+    end
+  end
+
+  describe "retrieve/2" do
+    test "retrieves a document type", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/document-types/type_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "type_abc",
+             "companyId" => "company_abc",
+             "name" => "Passport",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-01T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.DocumentTypes.retrieve(client, "type_abc")
+      assert response.name == "Passport"
+    end
+  end
+
+  describe "update/3" do
+    test "updates a document type", %{client: client} do
+      params = %{"name" => "Identity Document"}
+
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :method) == :patch
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/document-types/type_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "type_abc",
+             "companyId" => "company_abc",
+             "name" => "Identity Document",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-02T08:44:42.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.DocumentTypes.update(client, "type_abc", params)
+      assert response.name == "Identity Document"
+    end
+  end
+
+  test "delete/2 is not exported" do
+    refute function_exported?(Humaans.DocumentTypes, :delete, 2)
+  end
+end

--- a/test/humaans/document_types_test.exs
+++ b/test/humaans/document_types_test.exs
@@ -16,6 +16,7 @@ defmodule Humaans.DocumentTypesTest do
     test "returns a list of document types", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :get
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/document-types"
 
@@ -75,6 +76,7 @@ defmodule Humaans.DocumentTypesTest do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
         assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :post
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/document-types"
 
@@ -91,6 +93,7 @@ defmodule Humaans.DocumentTypesTest do
     test "retrieves a document type", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :get
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/document-types/type_abc"
 
@@ -119,6 +122,7 @@ defmodule Humaans.DocumentTypesTest do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
         assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :patch
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/document-types/type_abc"
 

--- a/test/humaans/documents_test.exs
+++ b/test/humaans/documents_test.exs
@@ -1,0 +1,182 @@
+defmodule Humaans.DocumentsTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.Documents
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "list/1" do
+    test "returns a list of documents", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/documents"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "total" => 1,
+             "limit" => 100,
+             "skip" => 0,
+             "data" => [
+               %{
+                 "id" => "doc_abc",
+                 "companyId" => "company_abc",
+                 "personId" => "person_abc",
+                 "name" => "Passport",
+                 "documentTypeId" => "type_abc",
+                 "folderId" => "folder_abc",
+                 "link" => nil,
+                 "fileId" => "file_abc",
+                 "file" => %{
+                   "id" => "file_abc",
+                   "url" => "https://files.example.com/passport.pdf",
+                   "filename" => "passport.pdf"
+                 },
+                 "source" => nil,
+                 "sourceId" => nil,
+                 "issueDate" => "2024-06-01",
+                 "createdBy" => "person_def",
+                 "createdAt" => "2025-01-01T08:44:42.000Z",
+                 "updatedAt" => "2025-01-01T14:52:21.000Z"
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, [response]} = Humaans.Documents.list(client)
+      assert response.id == "doc_abc"
+      assert response.company_id == "company_abc"
+      assert response.person_id == "person_abc"
+      assert response.name == "Passport"
+      assert response.document_type_id == "type_abc"
+      assert response.folder_id == "folder_abc"
+      assert response.link == nil
+      assert response.file_id == "file_abc"
+      assert response.file["filename"] == "passport.pdf"
+      assert response.issue_date == ~D[2024-06-01]
+      assert response.created_by == "person_def"
+      assert response.created_at == ~U[2025-01-01 08:44:42.000Z]
+      assert response.updated_at == ~U[2025-01-01 14:52:21.000Z]
+    end
+
+    test "returns error when resource is not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.Documents.list(client)
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:error, "boom"}
+      end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.Documents.list(client)
+    end
+  end
+
+  describe "create/2" do
+    test "creates a document", %{client: client} do
+      params = %{
+        "personId" => "person_abc",
+        "documentTypeId" => "type_abc",
+        "name" => "Passport",
+        "link" => "https://example.com/p.pdf"
+      }
+
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :method) == :post
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/documents"
+
+        {:ok, %{status: 201, body: Map.put(params, "id", "doc_new")}}
+      end)
+
+      assert {:ok, response} = Humaans.Documents.create(client, params)
+      assert response.id == "doc_new"
+      assert response.name == "Passport"
+    end
+  end
+
+  describe "retrieve/2" do
+    test "retrieves a document", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/documents/doc_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "doc_abc",
+             "name" => "Passport",
+             "documentTypeId" => "type_abc",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-01T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.Documents.retrieve(client, "doc_abc")
+      assert response.name == "Passport"
+    end
+  end
+
+  describe "update/3" do
+    test "updates a document", %{client: client} do
+      params = %{"name" => "Passport (renewed)"}
+
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :method) == :patch
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/documents/doc_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "doc_abc",
+             "name" => "Passport (renewed)",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-02T08:44:42.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.Documents.update(client, "doc_abc", params)
+      assert response.name == "Passport (renewed)"
+    end
+  end
+
+  describe "delete/2" do
+    test "deletes a document", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :delete
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/documents/doc_abc"
+
+        {:ok, %{status: 200, body: %{"id" => "doc_abc", "deleted" => true}}}
+      end)
+
+      assert {:ok, %{id: "doc_abc", deleted: true}} = Humaans.Documents.delete(client, "doc_abc")
+    end
+  end
+end

--- a/test/humaans/documents_test.exs
+++ b/test/humaans/documents_test.exs
@@ -16,6 +16,7 @@ defmodule Humaans.DocumentsTest do
     test "returns a list of documents", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :get
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/documents"
 
@@ -102,6 +103,7 @@ defmodule Humaans.DocumentsTest do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
         assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :post
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/documents"
 
@@ -118,6 +120,7 @@ defmodule Humaans.DocumentsTest do
     test "retrieves a document", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :get
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/documents/doc_abc"
 
@@ -146,6 +149,7 @@ defmodule Humaans.DocumentsTest do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
         assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :patch
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/documents/doc_abc"
 
@@ -170,6 +174,7 @@ defmodule Humaans.DocumentsTest do
     test "deletes a document", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :delete
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/documents/doc_abc"
 

--- a/test/humaans_test.exs
+++ b/test/humaans_test.exs
@@ -113,6 +113,18 @@ defmodule HumaansTest do
     assert Humaans.compensations() == Humaans.Compensations
   end
 
+  test "documents/0 returns the Documents module" do
+    assert Humaans.documents() == Humaans.Documents
+  end
+
+  test "document_types/0 returns the DocumentTypes module" do
+    assert Humaans.document_types() == Humaans.DocumentTypes
+  end
+
+  test "document_folders/0 returns the DocumentFolders module" do
+    assert Humaans.document_folders() == Humaans.DocumentFolders
+  end
+
   test "timesheet_entries/0 returns the TimesheetEntries module" do
     assert Humaans.timesheet_entries() == Humaans.TimesheetEntries
   end


### PR DESCRIPTION
:tipping_hand_person: These changes add CRUD coverage for the three Documents-related resources, foundational for any onboarding-pipeline integration.

## Summary

- `Humaans.Documents`: `/api/documents` (full CRUD, including nested file metadata)
- `Humaans.DocumentTypes`: `/api/document-types` (list/create/retrieve/update — the API does not support DELETE; a guard test asserts `delete/2` is not exported)
- `Humaans.DocumentFolders`: `/api/document-folders` (full CRUD, with audience-rules and `deletedAt`)

Each ships as struct + module + tests using `Humaans.Resource`. Helpers and README updated.

## Test plan

- [x] `mix test` passes (24 new tests)
- [x] `mix credo` clean
- [x] `mix format --check-formatted` clean