### PR TITLE
feat(org-structure): add Job Roles, Locations, and Spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,10 @@ Supported operators: `eq`, `in_`, `nin`, `gt`, `gte`, `lt`, `lte`. Use `Humaans.
 - `Humaans.DocumentFolders` - Work with document folder resources
 - `Humaans.DocumentTypes` - Work with document type resources
 - `Humaans.Documents` - Work with document resources
+- `Humaans.JobRoles` - Work with job role resources
+- `Humaans.Locations` - Work with location resources
 - `Humaans.Me` - Retrieve the authenticated user's profile (`GET /me`)
+- `Humaans.Spaces` - Work with space (team/department) resources
 - `Humaans.TimeAwayAdjustments` - Work with time away adjustment resources
 - `Humaans.TimeAwayAllocations` - Work with time away allocation resources
 - `Humaans.TimeAwayPolicies` - Work with time away policy resources

--- a/lib/humaans.ex
+++ b/lib/humaans.ex
@@ -206,6 +206,20 @@ defmodule Humaans do
   def document_folders, do: Humaans.DocumentFolders
 
   @doc """
+  Access the Job Roles API.
+
+  Returns the module that contains functions for working with job role resources.
+  """
+  def job_roles, do: Humaans.JobRoles
+
+  @doc """
+  Access the Locations API.
+
+  Returns the module that contains functions for working with location resources.
+  """
+  def locations, do: Humaans.Locations
+
+  @doc """
   Access the current user's profile.
 
   Returns `Humaans.Me`, which exposes `get/1` for retrieving the
@@ -236,6 +250,13 @@ defmodule Humaans do
   filter queries.
   """
   def query, do: Humaans.Query
+
+  @doc """
+  Access the Spaces API.
+
+  Returns the module that contains functions for working with space (team/department) resources.
+  """
+  def spaces, do: Humaans.Spaces
 
   @doc """
   Access the Timesheet Entries API.

--- a/lib/humaans/job_roles.ex
+++ b/lib/humaans/job_roles.ex
@@ -1,0 +1,18 @@
+defmodule Humaans.JobRoles do
+  @moduledoc """
+  This module provides functions for managing job role resources in the
+  Humaans API.
+  """
+
+  use Humaans.Resource,
+    path: "/job-roles",
+    struct: Humaans.Resources.JobRole,
+    doc_params: [
+      create: ~s(%{name: "Software Engineer"}),
+      update: ~s(%{name: "Senior Software Engineer"})
+    ]
+
+  @type delete_response :: {:ok, %{id: String.t(), deleted: bool()}} | {:error, Humaans.Error.t()}
+  @type list_response :: {:ok, [%Humaans.Resources.JobRole{}]} | {:error, Humaans.Error.t()}
+  @type response :: {:ok, %Humaans.Resources.JobRole{}} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/locations.ex
+++ b/lib/humaans/locations.ex
@@ -1,0 +1,18 @@
+defmodule Humaans.Locations do
+  @moduledoc """
+  This module provides functions for managing location resources in the
+  Humaans API.
+  """
+
+  use Humaans.Resource,
+    path: "/locations",
+    struct: Humaans.Resources.Location,
+    doc_params: [
+      create: ~s(%{name: "London HQ"}),
+      update: ~s(%{name: "London Office"})
+    ]
+
+  @type delete_response :: {:ok, %{id: String.t(), deleted: bool()}} | {:error, Humaans.Error.t()}
+  @type list_response :: {:ok, [%Humaans.Resources.Location{}]} | {:error, Humaans.Error.t()}
+  @type response :: {:ok, %Humaans.Resources.Location{}} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/resources/job_role.ex
+++ b/lib/humaans/resources/job_role.ex
@@ -1,0 +1,26 @@
+defmodule Humaans.Resources.JobRole do
+  @moduledoc """
+  Representation of a Job Role resource.
+  """
+
+  defstruct [:id, :company_id, :name, :created_at, :updated_at]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          company_id: binary | nil,
+          name: binary | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/resources/location.ex
+++ b/lib/humaans/resources/location.ex
@@ -1,0 +1,26 @@
+defmodule Humaans.Resources.Location do
+  @moduledoc """
+  Representation of a Location resource.
+  """
+
+  defstruct [:id, :company_id, :name, :created_at, :updated_at]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          company_id: binary | nil,
+          name: binary | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/resources/space.ex
+++ b/lib/humaans/resources/space.ex
@@ -1,0 +1,26 @@
+defmodule Humaans.Resources.Space do
+  @moduledoc """
+  Representation of a Space (team/department) resource.
+  """
+
+  defstruct [:id, :company_id, :name, :created_at, :updated_at]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          company_id: binary | nil,
+          name: binary | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/spaces.ex
+++ b/lib/humaans/spaces.ex
@@ -1,0 +1,18 @@
+defmodule Humaans.Spaces do
+  @moduledoc """
+  This module provides functions for managing space (team/department)
+  resources in the Humaans API.
+  """
+
+  use Humaans.Resource,
+    path: "/spaces",
+    struct: Humaans.Resources.Space,
+    doc_params: [
+      create: ~s(%{name: "Engineering"}),
+      update: ~s(%{name: "Platform Engineering"})
+    ]
+
+  @type delete_response :: {:ok, %{id: String.t(), deleted: bool()}} | {:error, Humaans.Error.t()}
+  @type list_response :: {:ok, [%Humaans.Resources.Space{}]} | {:error, Humaans.Error.t()}
+  @type response :: {:ok, %Humaans.Resources.Space{}} | {:error, Humaans.Error.t()}
+end

--- a/test/humaans/job_roles_test.exs
+++ b/test/humaans/job_roles_test.exs
@@ -1,0 +1,155 @@
+defmodule Humaans.JobRolesTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.JobRoles
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "list/1" do
+    test "returns a list of job roles", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/job-roles"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "total" => 1,
+             "limit" => 100,
+             "skip" => 0,
+             "data" => [
+               %{
+                 "id" => "role_abc",
+                 "companyId" => "company_abc",
+                 "name" => "Software Engineer",
+                 "createdAt" => "2025-01-01T08:44:42.000Z",
+                 "updatedAt" => "2025-01-01T14:52:21.000Z"
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, [response]} = Humaans.JobRoles.list(client)
+      assert response.id == "role_abc"
+      assert response.company_id == "company_abc"
+      assert response.name == "Software Engineer"
+      assert response.created_at == ~U[2025-01-01 08:44:42.000Z]
+      assert response.updated_at == ~U[2025-01-01 14:52:21.000Z]
+    end
+
+    test "returns error when resource is not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.JobRoles.list(client)
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:error, "boom"}
+      end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.JobRoles.list(client)
+    end
+  end
+
+  describe "create/2" do
+    test "creates a job role", %{client: client} do
+      params = %{"name" => "Software Engineer"}
+
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :method) == :post
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/job-roles"
+
+        {:ok, %{status: 201, body: Map.put(params, "id", "role_new")}}
+      end)
+
+      assert {:ok, response} = Humaans.JobRoles.create(client, params)
+      assert response.id == "role_new"
+    end
+  end
+
+  describe "retrieve/2" do
+    test "retrieves a job role", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/job-roles/role_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "role_abc",
+             "companyId" => "company_abc",
+             "name" => "Software Engineer",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-01T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.JobRoles.retrieve(client, "role_abc")
+      assert response.name == "Software Engineer"
+    end
+  end
+
+  describe "update/3" do
+    test "updates a job role", %{client: client} do
+      params = %{"name" => "Senior Software Engineer"}
+
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :method) == :patch
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/job-roles/role_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "role_abc",
+             "name" => "Senior Software Engineer",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-02T08:44:42.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.JobRoles.update(client, "role_abc", params)
+      assert response.name == "Senior Software Engineer"
+    end
+  end
+
+  describe "delete/2" do
+    test "deletes a job role", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :delete
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/job-roles/role_abc"
+
+        {:ok, %{status: 200, body: %{"id" => "role_abc", "deleted" => true}}}
+      end)
+
+      assert {:ok, %{id: "role_abc", deleted: true}} =
+               Humaans.JobRoles.delete(client, "role_abc")
+    end
+  end
+end

--- a/test/humaans/job_roles_test.exs
+++ b/test/humaans/job_roles_test.exs
@@ -16,6 +16,7 @@ defmodule Humaans.JobRolesTest do
     test "returns a list of job roles", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :get
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/job-roles"
 
@@ -75,6 +76,7 @@ defmodule Humaans.JobRolesTest do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
         assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :post
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/job-roles"
 
@@ -90,6 +92,7 @@ defmodule Humaans.JobRolesTest do
     test "retrieves a job role", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :get
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/job-roles/role_abc"
 
@@ -118,6 +121,7 @@ defmodule Humaans.JobRolesTest do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
         assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :patch
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/job-roles/role_abc"
 
@@ -142,6 +146,7 @@ defmodule Humaans.JobRolesTest do
     test "deletes a job role", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :delete
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/job-roles/role_abc"
 

--- a/test/humaans/locations_test.exs
+++ b/test/humaans/locations_test.exs
@@ -1,0 +1,153 @@
+defmodule Humaans.LocationsTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.Locations
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "list/1" do
+    test "returns a list of locations", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/locations"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "total" => 1,
+             "limit" => 100,
+             "skip" => 0,
+             "data" => [
+               %{
+                 "id" => "loc_abc",
+                 "companyId" => "company_abc",
+                 "name" => "London HQ",
+                 "createdAt" => "2025-01-01T08:44:42.000Z",
+                 "updatedAt" => "2025-01-01T14:52:21.000Z"
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, [response]} = Humaans.Locations.list(client)
+      assert response.id == "loc_abc"
+      assert response.name == "London HQ"
+      assert response.created_at == ~U[2025-01-01 08:44:42.000Z]
+    end
+
+    test "returns error when resource is not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.Locations.list(client)
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:error, "boom"}
+      end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.Locations.list(client)
+    end
+  end
+
+  describe "create/2" do
+    test "creates a location", %{client: client} do
+      params = %{"name" => "London HQ"}
+
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :method) == :post
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/locations"
+
+        {:ok, %{status: 201, body: Map.put(params, "id", "loc_new")}}
+      end)
+
+      assert {:ok, response} = Humaans.Locations.create(client, params)
+      assert response.id == "loc_new"
+    end
+  end
+
+  describe "retrieve/2" do
+    test "retrieves a location", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/locations/loc_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "loc_abc",
+             "companyId" => "company_abc",
+             "name" => "London HQ",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-01T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.Locations.retrieve(client, "loc_abc")
+      assert response.name == "London HQ"
+    end
+  end
+
+  describe "update/3" do
+    test "updates a location", %{client: client} do
+      params = %{"name" => "London Office"}
+
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :method) == :patch
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/locations/loc_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "loc_abc",
+             "name" => "London Office",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-02T08:44:42.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.Locations.update(client, "loc_abc", params)
+      assert response.name == "London Office"
+    end
+  end
+
+  describe "delete/2" do
+    test "deletes a location", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :delete
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/locations/loc_abc"
+
+        {:ok, %{status: 200, body: %{"id" => "loc_abc", "deleted" => true}}}
+      end)
+
+      assert {:ok, %{id: "loc_abc", deleted: true}} =
+               Humaans.Locations.delete(client, "loc_abc")
+    end
+  end
+end

--- a/test/humaans/locations_test.exs
+++ b/test/humaans/locations_test.exs
@@ -16,6 +16,7 @@ defmodule Humaans.LocationsTest do
     test "returns a list of locations", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :get
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/locations"
 
@@ -73,6 +74,7 @@ defmodule Humaans.LocationsTest do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
         assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :post
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/locations"
 
@@ -88,6 +90,7 @@ defmodule Humaans.LocationsTest do
     test "retrieves a location", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :get
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/locations/loc_abc"
 
@@ -116,6 +119,7 @@ defmodule Humaans.LocationsTest do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
         assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :patch
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/locations/loc_abc"
 
@@ -140,6 +144,7 @@ defmodule Humaans.LocationsTest do
     test "deletes a location", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :delete
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/locations/loc_abc"
 

--- a/test/humaans/locations_test.exs
+++ b/test/humaans/locations_test.exs
@@ -42,8 +42,10 @@ defmodule Humaans.LocationsTest do
 
       assert {:ok, [response]} = Humaans.Locations.list(client)
       assert response.id == "loc_abc"
+      assert response.company_id == "company_abc"
       assert response.name == "London HQ"
       assert response.created_at == ~U[2025-01-01 08:44:42.000Z]
+      assert response.updated_at == ~U[2025-01-01 14:52:21.000Z]
     end
 
     test "returns error when resource is not found", %{client: client} do

--- a/test/humaans/spaces_test.exs
+++ b/test/humaans/spaces_test.exs
@@ -1,0 +1,152 @@
+defmodule Humaans.SpacesTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.Spaces
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "list/1" do
+    test "returns a list of spaces", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/spaces"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "total" => 1,
+             "limit" => 100,
+             "skip" => 0,
+             "data" => [
+               %{
+                 "id" => "space_abc",
+                 "companyId" => "company_abc",
+                 "name" => "Engineering",
+                 "createdAt" => "2025-01-01T08:44:42.000Z",
+                 "updatedAt" => "2025-01-01T14:52:21.000Z"
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, [response]} = Humaans.Spaces.list(client)
+      assert response.id == "space_abc"
+      assert response.name == "Engineering"
+    end
+
+    test "returns error when resource is not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.Spaces.list(client)
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:error, "boom"}
+      end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.Spaces.list(client)
+    end
+  end
+
+  describe "create/2" do
+    test "creates a space", %{client: client} do
+      params = %{"name" => "Engineering"}
+
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :method) == :post
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/spaces"
+
+        {:ok, %{status: 201, body: Map.put(params, "id", "space_new")}}
+      end)
+
+      assert {:ok, response} = Humaans.Spaces.create(client, params)
+      assert response.id == "space_new"
+    end
+  end
+
+  describe "retrieve/2" do
+    test "retrieves a space", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/spaces/space_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "space_abc",
+             "companyId" => "company_abc",
+             "name" => "Engineering",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-01T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.Spaces.retrieve(client, "space_abc")
+      assert response.name == "Engineering"
+    end
+  end
+
+  describe "update/3" do
+    test "updates a space", %{client: client} do
+      params = %{"name" => "Platform Engineering"}
+
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :method) == :patch
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/spaces/space_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "space_abc",
+             "name" => "Platform Engineering",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-02T08:44:42.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.Spaces.update(client, "space_abc", params)
+      assert response.name == "Platform Engineering"
+    end
+  end
+
+  describe "delete/2" do
+    test "deletes a space", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :delete
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/spaces/space_abc"
+
+        {:ok, %{status: 200, body: %{"id" => "space_abc", "deleted" => true}}}
+      end)
+
+      assert {:ok, %{id: "space_abc", deleted: true}} =
+               Humaans.Spaces.delete(client, "space_abc")
+    end
+  end
+end

--- a/test/humaans/spaces_test.exs
+++ b/test/humaans/spaces_test.exs
@@ -16,6 +16,7 @@ defmodule Humaans.SpacesTest do
     test "returns a list of spaces", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :get
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/spaces"
 
@@ -72,6 +73,7 @@ defmodule Humaans.SpacesTest do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
         assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :post
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/spaces"
 
@@ -87,6 +89,7 @@ defmodule Humaans.SpacesTest do
     test "retrieves a space", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :get
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/spaces/space_abc"
 
@@ -115,6 +118,7 @@ defmodule Humaans.SpacesTest do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
         assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :patch
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/spaces/space_abc"
 
@@ -139,6 +143,7 @@ defmodule Humaans.SpacesTest do
     test "deletes a space", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :delete
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/spaces/space_abc"
 

--- a/test/humaans/spaces_test.exs
+++ b/test/humaans/spaces_test.exs
@@ -42,7 +42,10 @@ defmodule Humaans.SpacesTest do
 
       assert {:ok, [response]} = Humaans.Spaces.list(client)
       assert response.id == "space_abc"
+      assert response.company_id == "company_abc"
       assert response.name == "Engineering"
+      assert response.created_at == ~U[2025-01-01 08:44:42.000Z]
+      assert response.updated_at == ~U[2025-01-01 14:52:21.000Z]
     end
 
     test "returns error when resource is not found", %{client: client} do

--- a/test/humaans_test.exs
+++ b/test/humaans_test.exs
@@ -125,6 +125,18 @@ defmodule HumaansTest do
     assert Humaans.document_folders() == Humaans.DocumentFolders
   end
 
+  test "job_roles/0 returns the JobRoles module" do
+    assert Humaans.job_roles() == Humaans.JobRoles
+  end
+
+  test "locations/0 returns the Locations module" do
+    assert Humaans.locations() == Humaans.Locations
+  end
+
+  test "spaces/0 returns the Spaces module" do
+    assert Humaans.spaces() == Humaans.Spaces
+  end
+
   test "timesheet_entries/0 returns the TimesheetEntries module" do
     assert Humaans.timesheet_entries() == Humaans.TimesheetEntries
   end


### PR DESCRIPTION
:tipping_hand_person: These changes add CRUD coverage for the three core organisation-structure resources.

## Summary

- `Humaans.JobRoles`: `/api/job-roles` (named positions)
- `Humaans.Locations`: `/api/locations` (offices/sites that `person.locationId` references)
- `Humaans.Spaces`: `/api/spaces` (teams/departments)

All three share the same documented shape (`id`, `companyId`, `name`, `createdAt`, `updatedAt`) and ship as struct + module + tests using `Humaans.Resource`. Helpers and README updated.

## Test plan

- [x] `mix test` passes (21 new tests)
- [x] `mix credo` clean
- [x] `mix format --check-formatted` clean