### PR TITLE
feat(working-patterns): add Working Patterns and Allocations CRUD

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ Supported operators: `eq`, `in_`, `nin`, `gt`, `gte`, `lt`, `lte`. Use `Humaans.
 - `Humaans.TimesheetEntries` - Work with timesheet entry resources
 - `Humaans.TimesheetSubmissions` - Work with timesheet submission resources
 - `Humaans.TokenInfo` - Retrieve metadata about the current access token (`GET /token-info`)
+- `Humaans.WorkingPatterns` - Work with working pattern resources
+- `Humaans.WorkingPatternAllocations` - Work with working pattern allocation resources
 
 ## Development
 

--- a/lib/humaans.ex
+++ b/lib/humaans.ex
@@ -322,4 +322,18 @@ defmodule Humaans do
   verifying HMAC-SHA256 webhook signatures.
   """
   def webhooks, do: Humaans.Webhooks
+
+  @doc """
+  Access the Working Patterns API.
+
+  Returns the module that contains functions for working with working pattern resources.
+  """
+  def working_patterns, do: Humaans.WorkingPatterns
+
+  @doc """
+  Access the Working Pattern Allocations API.
+
+  Returns the module that contains functions for working with working pattern allocation resources.
+  """
+  def working_pattern_allocations, do: Humaans.WorkingPatternAllocations
 end

--- a/lib/humaans/resources/working_pattern.ex
+++ b/lib/humaans/resources/working_pattern.ex
@@ -1,0 +1,26 @@
+defmodule Humaans.Resources.WorkingPattern do
+  @moduledoc """
+  Representation of a Working Pattern resource.
+  """
+
+  defstruct [:id, :company_id, :name, :created_at, :updated_at]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          company_id: binary | nil,
+          name: binary | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/resources/working_pattern_allocation.ex
+++ b/lib/humaans/resources/working_pattern_allocation.ex
@@ -1,0 +1,38 @@
+defmodule Humaans.Resources.WorkingPatternAllocation do
+  @moduledoc """
+  Representation of a Working Pattern Allocation resource.
+  """
+
+  defstruct [
+    :id,
+    :person_id,
+    :working_pattern_id,
+    :start_date,
+    :end_date,
+    :created_at,
+    :updated_at
+  ]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_date(:start_date)
+    |> parse_date(:end_date)
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          person_id: binary | nil,
+          working_pattern_id: binary | nil,
+          start_date: Date.t() | nil,
+          end_date: Date.t() | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/working_pattern_allocations.ex
+++ b/lib/humaans/working_pattern_allocations.ex
@@ -1,0 +1,20 @@
+defmodule Humaans.WorkingPatternAllocations do
+  @moduledoc """
+  This module provides functions for managing working pattern allocation
+  resources in the Humaans API.
+  """
+
+  use Humaans.Resource,
+    path: "/working-pattern-allocations",
+    struct: Humaans.Resources.WorkingPatternAllocation,
+    doc_params: [
+      create: ~s(%{personId: "person_abc", workingPatternId: "wp_abc", startDate: "2025-01-01"}),
+      update: ~s(%{endDate: "2025-12-31"})
+    ]
+
+  @type delete_response :: {:ok, %{id: String.t(), deleted: bool()}} | {:error, Humaans.Error.t()}
+  @type list_response ::
+          {:ok, [%Humaans.Resources.WorkingPatternAllocation{}]} | {:error, Humaans.Error.t()}
+  @type response ::
+          {:ok, %Humaans.Resources.WorkingPatternAllocation{}} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/working_patterns.ex
+++ b/lib/humaans/working_patterns.ex
@@ -1,0 +1,19 @@
+defmodule Humaans.WorkingPatterns do
+  @moduledoc """
+  This module provides functions for managing working pattern resources in
+  the Humaans API.
+  """
+
+  use Humaans.Resource,
+    path: "/working-patterns",
+    struct: Humaans.Resources.WorkingPattern,
+    doc_params: [
+      create: ~s(%{name: "Mon-Fri 9-5"}),
+      update: ~s(%{name: "Mon-Thu 9-5"})
+    ]
+
+  @type delete_response :: {:ok, %{id: String.t(), deleted: bool()}} | {:error, Humaans.Error.t()}
+  @type list_response ::
+          {:ok, [%Humaans.Resources.WorkingPattern{}]} | {:error, Humaans.Error.t()}
+  @type response :: {:ok, %Humaans.Resources.WorkingPattern{}} | {:error, Humaans.Error.t()}
+end

--- a/test/humaans/working_pattern_allocations_test.exs
+++ b/test/humaans/working_pattern_allocations_test.exs
@@ -1,0 +1,180 @@
+defmodule Humaans.WorkingPatternAllocationsTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.WorkingPatternAllocations
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "list/1" do
+    test "returns a list of working pattern allocations", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/working-pattern-allocations"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "total" => 1,
+             "limit" => 100,
+             "skip" => 0,
+             "data" => [
+               %{
+                 "id" => "wpa_abc",
+                 "personId" => "person_abc",
+                 "workingPatternId" => "wp_abc",
+                 "startDate" => "2025-01-01",
+                 "endDate" => "2025-12-31",
+                 "createdAt" => "2025-01-01T08:44:42.000Z",
+                 "updatedAt" => "2025-01-01T14:52:21.000Z"
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, [response]} = Humaans.WorkingPatternAllocations.list(client)
+      assert response.id == "wpa_abc"
+      assert response.person_id == "person_abc"
+      assert response.working_pattern_id == "wp_abc"
+      assert response.start_date == ~D[2025-01-01]
+      assert response.end_date == ~D[2025-12-31]
+      assert response.created_at == ~U[2025-01-01 08:44:42.000Z]
+    end
+
+    test "returns error when resource is not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.WorkingPatternAllocations.list(client)
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:error, "boom"}
+      end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.WorkingPatternAllocations.list(client)
+    end
+  end
+
+  describe "create/2" do
+    test "creates a working pattern allocation", %{client: client} do
+      params = %{
+        "personId" => "person_abc",
+        "workingPatternId" => "wp_abc",
+        "startDate" => "2025-01-01"
+      }
+
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :method) == :post
+
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/working-pattern-allocations"
+
+        {:ok, %{status: 201, body: Map.put(params, "id", "wpa_new")}}
+      end)
+
+      assert {:ok, response} = Humaans.WorkingPatternAllocations.create(client, params)
+      assert response.id == "wpa_new"
+      assert response.start_date == ~D[2025-01-01]
+    end
+  end
+
+  describe "retrieve/2" do
+    test "retrieves a working pattern allocation", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/working-pattern-allocations/wpa_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "wpa_abc",
+             "personId" => "person_abc",
+             "workingPatternId" => "wp_abc",
+             "startDate" => "2025-01-01",
+             "endDate" => nil,
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-01T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.WorkingPatternAllocations.retrieve(client, "wpa_abc")
+      assert response.end_date == nil
+    end
+  end
+
+  describe "update/3" do
+    test "updates a working pattern allocation", %{client: client} do
+      params = %{"endDate" => "2025-12-31"}
+
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :method) == :patch
+
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/working-pattern-allocations/wpa_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "wpa_abc",
+             "personId" => "person_abc",
+             "workingPatternId" => "wp_abc",
+             "startDate" => "2025-01-01",
+             "endDate" => "2025-12-31",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-02T08:44:42.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} =
+               Humaans.WorkingPatternAllocations.update(client, "wpa_abc", params)
+
+      assert response.end_date == ~D[2025-12-31]
+    end
+  end
+
+  describe "delete/2" do
+    test "deletes a working pattern allocation", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :delete
+
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/working-pattern-allocations/wpa_abc"
+
+        {:ok, %{status: 200, body: %{"id" => "wpa_abc", "deleted" => true}}}
+      end)
+
+      assert {:ok, %{id: "wpa_abc", deleted: true}} =
+               Humaans.WorkingPatternAllocations.delete(client, "wpa_abc")
+    end
+  end
+end

--- a/test/humaans/working_pattern_allocations_test.exs
+++ b/test/humaans/working_pattern_allocations_test.exs
@@ -16,6 +16,7 @@ defmodule Humaans.WorkingPatternAllocationsTest do
     test "returns a list of working pattern allocations", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :get
 
         assert Keyword.fetch!(opts, :url) ==
@@ -50,6 +51,7 @@ defmodule Humaans.WorkingPatternAllocationsTest do
       assert response.start_date == ~D[2025-01-01]
       assert response.end_date == ~D[2025-12-31]
       assert response.created_at == ~U[2025-01-01 08:44:42.000Z]
+      assert response.updated_at == ~U[2025-01-01 14:52:21.000Z]
     end
 
     test "returns error when resource is not found", %{client: client} do
@@ -84,6 +86,7 @@ defmodule Humaans.WorkingPatternAllocationsTest do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
         assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :post
 
         assert Keyword.fetch!(opts, :url) ==
@@ -102,6 +105,7 @@ defmodule Humaans.WorkingPatternAllocationsTest do
     test "retrieves a working pattern allocation", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :get
 
         assert Keyword.fetch!(opts, :url) ==
@@ -134,6 +138,7 @@ defmodule Humaans.WorkingPatternAllocationsTest do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
         assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :patch
 
         assert Keyword.fetch!(opts, :url) ==
@@ -165,6 +170,7 @@ defmodule Humaans.WorkingPatternAllocationsTest do
     test "deletes a working pattern allocation", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :delete
 
         assert Keyword.fetch!(opts, :url) ==

--- a/test/humaans/working_patterns_test.exs
+++ b/test/humaans/working_patterns_test.exs
@@ -1,0 +1,152 @@
+defmodule Humaans.WorkingPatternsTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.WorkingPatterns
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "list/1" do
+    test "returns a list of working patterns", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/working-patterns"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "total" => 1,
+             "limit" => 100,
+             "skip" => 0,
+             "data" => [
+               %{
+                 "id" => "wp_abc",
+                 "companyId" => "company_abc",
+                 "name" => "Mon-Fri 9-5",
+                 "createdAt" => "2025-01-01T08:44:42.000Z",
+                 "updatedAt" => "2025-01-01T14:52:21.000Z"
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, [response]} = Humaans.WorkingPatterns.list(client)
+      assert response.id == "wp_abc"
+      assert response.name == "Mon-Fri 9-5"
+    end
+
+    test "returns error when resource is not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.WorkingPatterns.list(client)
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:error, "boom"}
+      end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.WorkingPatterns.list(client)
+    end
+  end
+
+  describe "create/2" do
+    test "creates a working pattern", %{client: client} do
+      params = %{"name" => "Mon-Fri 9-5"}
+
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :method) == :post
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/working-patterns"
+
+        {:ok, %{status: 201, body: Map.put(params, "id", "wp_new")}}
+      end)
+
+      assert {:ok, response} = Humaans.WorkingPatterns.create(client, params)
+      assert response.id == "wp_new"
+    end
+  end
+
+  describe "retrieve/2" do
+    test "retrieves a working pattern", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/working-patterns/wp_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "wp_abc",
+             "companyId" => "company_abc",
+             "name" => "Mon-Fri 9-5",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-01T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.WorkingPatterns.retrieve(client, "wp_abc")
+      assert response.name == "Mon-Fri 9-5"
+    end
+  end
+
+  describe "update/3" do
+    test "updates a working pattern", %{client: client} do
+      params = %{"name" => "Mon-Thu 9-5"}
+
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :method) == :patch
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/working-patterns/wp_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "wp_abc",
+             "name" => "Mon-Thu 9-5",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-02T08:44:42.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.WorkingPatterns.update(client, "wp_abc", params)
+      assert response.name == "Mon-Thu 9-5"
+    end
+  end
+
+  describe "delete/2" do
+    test "deletes a working pattern", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :delete
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/working-patterns/wp_abc"
+
+        {:ok, %{status: 200, body: %{"id" => "wp_abc", "deleted" => true}}}
+      end)
+
+      assert {:ok, %{id: "wp_abc", deleted: true}} =
+               Humaans.WorkingPatterns.delete(client, "wp_abc")
+    end
+  end
+end

--- a/test/humaans/working_patterns_test.exs
+++ b/test/humaans/working_patterns_test.exs
@@ -16,6 +16,7 @@ defmodule Humaans.WorkingPatternsTest do
     test "returns a list of working patterns", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :get
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/working-patterns"
 
@@ -41,7 +42,10 @@ defmodule Humaans.WorkingPatternsTest do
 
       assert {:ok, [response]} = Humaans.WorkingPatterns.list(client)
       assert response.id == "wp_abc"
+      assert response.company_id == "company_abc"
       assert response.name == "Mon-Fri 9-5"
+      assert response.created_at == ~U[2025-01-01 08:44:42.000Z]
+      assert response.updated_at == ~U[2025-01-01 14:52:21.000Z]
     end
 
     test "returns error when resource is not found", %{client: client} do
@@ -72,14 +76,29 @@ defmodule Humaans.WorkingPatternsTest do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
         assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :post
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/working-patterns"
 
-        {:ok, %{status: 201, body: Map.put(params, "id", "wp_new")}}
+        {:ok,
+         %{
+           status: 201,
+           body:
+             Map.merge(params, %{
+               "id" => "wp_new",
+               "companyId" => "company_abc",
+               "createdAt" => "2025-01-01T08:44:42.000Z",
+               "updatedAt" => "2025-01-01T14:52:21.000Z"
+             })
+         }}
       end)
 
       assert {:ok, response} = Humaans.WorkingPatterns.create(client, params)
       assert response.id == "wp_new"
+      assert response.company_id == "company_abc"
+      assert response.name == "Mon-Fri 9-5"
+      assert response.created_at == ~U[2025-01-01 08:44:42.000Z]
+      assert response.updated_at == ~U[2025-01-01 14:52:21.000Z]
     end
   end
 
@@ -87,6 +106,7 @@ defmodule Humaans.WorkingPatternsTest do
     test "retrieves a working pattern", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :get
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/working-patterns/wp_abc"
 
@@ -104,7 +124,11 @@ defmodule Humaans.WorkingPatternsTest do
       end)
 
       assert {:ok, response} = Humaans.WorkingPatterns.retrieve(client, "wp_abc")
+      assert response.id == "wp_abc"
+      assert response.company_id == "company_abc"
       assert response.name == "Mon-Fri 9-5"
+      assert response.created_at == ~U[2025-01-01 08:44:42.000Z]
+      assert response.updated_at == ~U[2025-01-01 14:52:21.000Z]
     end
   end
 
@@ -115,6 +139,7 @@ defmodule Humaans.WorkingPatternsTest do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
         assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :patch
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/working-patterns/wp_abc"
 
@@ -123,6 +148,7 @@ defmodule Humaans.WorkingPatternsTest do
            status: 200,
            body: %{
              "id" => "wp_abc",
+             "companyId" => "company_abc",
              "name" => "Mon-Thu 9-5",
              "createdAt" => "2025-01-01T08:44:42.000Z",
              "updatedAt" => "2025-01-02T08:44:42.000Z"
@@ -131,7 +157,11 @@ defmodule Humaans.WorkingPatternsTest do
       end)
 
       assert {:ok, response} = Humaans.WorkingPatterns.update(client, "wp_abc", params)
+      assert response.id == "wp_abc"
+      assert response.company_id == "company_abc"
       assert response.name == "Mon-Thu 9-5"
+      assert response.created_at == ~U[2025-01-01 08:44:42.000Z]
+      assert response.updated_at == ~U[2025-01-02 08:44:42.000Z]
     end
   end
 
@@ -139,6 +169,7 @@ defmodule Humaans.WorkingPatternsTest do
     test "deletes a working pattern", %{client: client} do
       expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
         assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
         assert Keyword.fetch!(opts, :method) == :delete
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/working-patterns/wp_abc"
 

--- a/test/humaans_test.exs
+++ b/test/humaans_test.exs
@@ -176,4 +176,12 @@ defmodule HumaansTest do
   test "query/0 returns the Query module" do
     assert Humaans.query() == Humaans.Query
   end
+
+  test "working_patterns/0 returns the WorkingPatterns module" do
+    assert Humaans.working_patterns() == Humaans.WorkingPatterns
+  end
+
+  test "working_pattern_allocations/0 returns the WorkingPatternAllocations module" do
+    assert Humaans.working_pattern_allocations() == Humaans.WorkingPatternAllocations
+  end
 end


### PR DESCRIPTION
:tipping_hand_person: These changes add CRUD coverage for Working Patterns and Working Pattern Allocations.

## Summary

- `Humaans.WorkingPatterns`: `/api/working-patterns` (named schedule definitions)
- `Humaans.WorkingPatternAllocations`: `/api/working-pattern-allocations` (per-person assignments within a date window)

Both ship as struct + module + tests using `Humaans.Resource`. Helpers and README updated.

The Working Pattern struct only declares the documented top-level fields (`id`, `companyId`, `name`, timestamps); deeper schedule-shape fields (e.g. day-of-week breakdowns) are not exposed in the public API reference excerpt and can be added additively if required.

## Test plan

- [x] `mix test` passes (14 new tests)
- [x] `mix credo` clean
- [x] `mix format --check-formatted` clean