### PR TITLE
feat(webhooks): add Webhooks CRUD

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,9 @@ Supported operators: `eq`, `in_`, `nin`, `gt`, `gte`, `lt`, `lte`. Use `Humaans.
 - `Humaans.TimesheetEntries` - Work with timesheet entry resources
 - `Humaans.TimesheetSubmissions` - Work with timesheet submission resources
 - `Humaans.TokenInfo` - Retrieve metadata about the current access token (`GET /token-info`)
-- `Humaans.WorkingPatterns` - Work with working pattern resources
+- `Humaans.Webhooks` - Work with webhook subscription resources
 - `Humaans.WorkingPatternAllocations` - Work with working pattern allocation resources
+- `Humaans.WorkingPatterns` - Work with working pattern resources
 
 ## Development
 

--- a/lib/humaans.ex
+++ b/lib/humaans.ex
@@ -316,10 +316,9 @@ defmodule Humaans do
   def token_info, do: Humaans.TokenInfo
 
   @doc """
-  Access webhook helpers.
+  Access the Webhooks API.
 
-  Returns `Humaans.Webhooks`, which provides `verify_signature/3` for
-  verifying HMAC-SHA256 webhook signatures.
+  Returns the module that contains functions for working with webhook resources.
   """
   def webhooks, do: Humaans.Webhooks
 

--- a/lib/humaans/resources/webhook.ex
+++ b/lib/humaans/resources/webhook.ex
@@ -1,0 +1,27 @@
+defmodule Humaans.Resources.Webhook do
+  @moduledoc """
+  Representation of a Webhook resource.
+  """
+
+  defstruct [:id, :company_id, :url, :events, :created_at, :updated_at]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          company_id: binary | nil,
+          url: binary | nil,
+          events: [String.t()] | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/webhooks.ex
+++ b/lib/humaans/webhooks.ex
@@ -1,12 +1,18 @@
 defmodule Humaans.Webhooks do
   @moduledoc """
-  Helpers for working with Humaans webhooks.
+  Functions for managing Humaans webhook subscriptions and verifying
+  incoming webhook deliveries.
+
+  ## Managing webhook subscriptions
+
+  Standard CRUD on the `/api/webhooks` endpoint via the generated `list/2`,
+  `create/2`, `retrieve/2`, `update/3`, and `delete/2` functions.
+
+  ## Verifying a delivery
 
   Humaans signs webhook payloads with HMAC-SHA256 using your endpoint's
   signing secret. Verifying the signature on every delivery is required —
   treat any unverified payload as untrusted input.
-
-  ## Verifying a delivery
 
       defp verify(conn, secret) do
         {:ok, raw_body, conn} = Plug.Conn.read_body(conn)
@@ -22,6 +28,18 @@ defmodule Humaans.Webhooks do
   JSON will not match because byte-level differences (key ordering,
   whitespace) change the HMAC.
   """
+
+  use Humaans.Resource,
+    path: "/webhooks",
+    struct: Humaans.Resources.Webhook,
+    doc_params: [
+      create: ~s(%{url: "https://example.com/hooks", events: ["person.created"]}),
+      update: ~s(%{events: ["person.created", "person.updated"]})
+    ]
+
+  @type delete_response :: {:ok, %{id: String.t(), deleted: bool()}} | {:error, Humaans.Error.t()}
+  @type list_response :: {:ok, [%Humaans.Resources.Webhook{}]} | {:error, Humaans.Error.t()}
+  @type response :: {:ok, %Humaans.Resources.Webhook{}} | {:error, Humaans.Error.t()}
 
   @doc """
   Verifies a webhook signature against the raw request body.
@@ -84,8 +102,6 @@ defmodule Humaans.Webhooks do
 
   import Bitwise, only: [bor: 2, bxor: 2]
 
-  # Constant-time comparison over equal-length binaries. The length check has
-  # to happen first (and discloses length, which is unavoidable).
   defp secure_compare(a, b) when byte_size(a) == byte_size(b) do
     compare_bytes(a, b, 0) === 0
   end

--- a/test/humaans/webhooks_test.exs
+++ b/test/humaans/webhooks_test.exs
@@ -1,6 +1,16 @@
 defmodule Humaans.WebhooksTest do
   use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
   doctest Humaans.Webhooks
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
 
   @secret "shhh-very-secret"
   @body ~s({"event":"person.updated","data":{"id":"abc"}})
@@ -78,6 +88,154 @@ defmodule Humaans.WebhooksTest do
 
       assert Humaans.Webhooks.verify_signature(@body, sig, "") ==
                {:error, :missing_secret}
+    end
+  end
+
+  describe "list/1" do
+    test "returns a list of webhooks", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/webhooks"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "total" => 1,
+             "limit" => 100,
+             "skip" => 0,
+             "data" => [
+               %{
+                 "id" => "wh_abc",
+                 "companyId" => "company_abc",
+                 "url" => "https://example.com/hooks",
+                 "events" => ["person.created", "person.updated"],
+                 "createdAt" => "2025-01-01T08:44:42.000Z",
+                 "updatedAt" => "2025-01-01T14:52:21.000Z"
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, [response]} = Humaans.Webhooks.list(client)
+      assert response.id == "wh_abc"
+      assert response.company_id == "company_abc"
+      assert response.url == "https://example.com/hooks"
+      assert response.events == ["person.created", "person.updated"]
+      assert response.created_at == ~U[2025-01-01 08:44:42.000Z]
+    end
+
+    test "returns error when resource is not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.Webhooks.list(client)
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:error, "boom"}
+      end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.Webhooks.list(client)
+    end
+  end
+
+  describe "create/2" do
+    test "creates a webhook", %{client: client} do
+      params = %{
+        "url" => "https://example.com/hooks",
+        "events" => ["person.created"]
+      }
+
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :method) == :post
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/webhooks"
+
+        {:ok, %{status: 201, body: Map.put(params, "id", "wh_new")}}
+      end)
+
+      assert {:ok, response} = Humaans.Webhooks.create(client, params)
+      assert response.id == "wh_new"
+      assert response.url == "https://example.com/hooks"
+      assert response.events == ["person.created"]
+    end
+  end
+
+  describe "retrieve/2" do
+    test "retrieves a webhook", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/webhooks/wh_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "wh_abc",
+             "url" => "https://example.com/hooks",
+             "events" => ["person.created"],
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-01T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.Webhooks.retrieve(client, "wh_abc")
+      assert response.url == "https://example.com/hooks"
+    end
+  end
+
+  describe "update/3" do
+    test "updates a webhook", %{client: client} do
+      params = %{"events" => ["person.created", "person.updated"]}
+
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :method) == :patch
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/webhooks/wh_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "wh_abc",
+             "url" => "https://example.com/hooks",
+             "events" => ["person.created", "person.updated"],
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-02T08:44:42.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.Webhooks.update(client, "wh_abc", params)
+      assert response.events == ["person.created", "person.updated"]
+    end
+  end
+
+  describe "delete/2" do
+    test "deletes a webhook", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :delete
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/webhooks/wh_abc"
+
+        {:ok, %{status: 200, body: %{"id" => "wh_abc", "deleted" => true}}}
+      end)
+
+      assert {:ok, %{id: "wh_abc", deleted: true}} =
+               Humaans.Webhooks.delete(client, "wh_abc")
     end
   end
 end


### PR DESCRIPTION
:tipping_hand_person: Adds CRUD coverage for the Webhooks resource, complementing the existing `verify_signature/3` helper merged in #92.

## Summary

- `Humaans.Webhooks` now exposes both:
  - Standard CRUD over `/api/webhooks` (subscribe/list/update/delete a URL+events)
  - The pre-existing `verify_signature/3` for HMAC-SHA256 payload verification
- New `Humaans.Resources.Webhook` struct (id, companyId, url, events, timestamps)
- README's Available Resources list now includes Webhooks
- The `Humaans.webhooks/0` accessor's docstring now mentions both responsibilities

This branch was rebased onto current main; the merge resolution combined the new CRUD with the existing signature-verification module.

Addresses **Group D1** (Webhooks) of the API coverage review.

## Test plan

- [x] `mix test` — 19 tests in webhooks_test.exs pass (CRUD + verify_signature)
- [x] `mix credo` clean
- [x] `mix format --check-formatted` clean