### PR TITLE
feat(profile-family): add D2 employee profile resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,18 @@ Supported operators: `eq`, `in_`, `nin`, `gt`, `gte`, `lt`, `lte`. Use `Humaans.
 - `Humaans.DocumentFolders` - Work with document folder resources
 - `Humaans.DocumentTypes` - Work with document type resources
 - `Humaans.Documents` - Work with document resources
+- `Humaans.EmergencyContacts` - Work with emergency contact resources
+- `Humaans.EquipmentNames` - List equipment names (read-only)
+- `Humaans.EquipmentTypes` - List equipment types (read-only)
+- `Humaans.Equipment` - Work with equipment resources
+- `Humaans.IdentityDocumentTypes` - List identity document types (read-only)
+- `Humaans.IdentityDocuments` - Work with identity document resources
 - `Humaans.JobRoles` - Work with job role resources
 - `Humaans.Locations` - Work with location resources
 - `Humaans.Me` - Retrieve the authenticated user's profile (`GET /me`)
+- `Humaans.PublicHolidayCalendarDays` - Work with public holiday calendar day resources
+- `Humaans.PublicHolidayCalendars` - List public holiday calendars (read-only)
+- `Humaans.PublicHolidays` - List public holidays (read-only)
 - `Humaans.Spaces` - Work with space (team/department) resources
 - `Humaans.TimeAwayAdjustments` - Work with time away adjustment resources
 - `Humaans.TimeAwayAllocations` - Work with time away allocation resources

--- a/lib/humaans.ex
+++ b/lib/humaans.ex
@@ -206,6 +206,48 @@ defmodule Humaans do
   def document_folders, do: Humaans.DocumentFolders
 
   @doc """
+  Access the Emergency Contacts API.
+
+  Returns the module that contains functions for working with emergency contact resources.
+  """
+  def emergency_contacts, do: Humaans.EmergencyContacts
+
+  @doc """
+  Access the Equipment API.
+
+  Returns the module that contains functions for working with equipment resources.
+  """
+  def equipment, do: Humaans.Equipment
+
+  @doc """
+  Access the Equipment Types API.
+
+  Returns the module that contains functions for working with equipment type resources.
+  """
+  def equipment_types, do: Humaans.EquipmentTypes
+
+  @doc """
+  Access the Equipment Names API.
+
+  Returns the module that contains functions for working with equipment name resources.
+  """
+  def equipment_names, do: Humaans.EquipmentNames
+
+  @doc """
+  Access the Identity Documents API.
+
+  Returns the module that contains functions for working with identity document resources.
+  """
+  def identity_documents, do: Humaans.IdentityDocuments
+
+  @doc """
+  Access the Identity Document Types API.
+
+  Returns the module that contains functions for working with identity document type resources.
+  """
+  def identity_document_types, do: Humaans.IdentityDocumentTypes
+
+  @doc """
   Access the Job Roles API.
 
   Returns the module that contains functions for working with job role resources.
@@ -241,6 +283,27 @@ defmodule Humaans do
   Returns the module that contains functions for working with people resources.
   """
   def people, do: Humaans.People
+
+  @doc """
+  Access the Public Holiday Calendars API.
+
+  Returns the module that contains functions for working with public holiday calendar resources.
+  """
+  def public_holiday_calendars, do: Humaans.PublicHolidayCalendars
+
+  @doc """
+  Access the Public Holiday Calendar Days API.
+
+  Returns the module that contains functions for working with public holiday calendar day resources.
+  """
+  def public_holiday_calendar_days, do: Humaans.PublicHolidayCalendarDays
+
+  @doc """
+  Access the Public Holidays API.
+
+  Returns the module that contains functions for working with public holiday resources.
+  """
+  def public_holidays, do: Humaans.PublicHolidays
 
   @doc """
   Access the query builder.

--- a/lib/humaans/emergency_contacts.ex
+++ b/lib/humaans/emergency_contacts.ex
@@ -1,0 +1,20 @@
+defmodule Humaans.EmergencyContacts do
+  @moduledoc """
+  This module provides functions for managing emergency contact resources in
+  the Humaans API.
+  """
+
+  use Humaans.Resource,
+    path: "/emergency-contacts",
+    struct: Humaans.Resources.EmergencyContact,
+    doc_params: [
+      create:
+        ~s(%{personId: "person_abc", name: "Jane Doe", relationship: "Sibling", phoneNumber: "+44 7700 900000"}),
+      update: ~s(%{phoneNumber: "+44 7700 900001"})
+    ]
+
+  @type delete_response :: {:ok, %{id: String.t(), deleted: bool()}} | {:error, Humaans.Error.t()}
+  @type list_response ::
+          {:ok, [%Humaans.Resources.EmergencyContact{}]} | {:error, Humaans.Error.t()}
+  @type response :: {:ok, %Humaans.Resources.EmergencyContact{}} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/equipment.ex
+++ b/lib/humaans/equipment.ex
@@ -1,0 +1,19 @@
+defmodule Humaans.Equipment do
+  @moduledoc """
+  This module provides functions for managing equipment resources in the
+  Humaans API.
+  """
+
+  use Humaans.Resource,
+    path: "/equipment",
+    struct: Humaans.Resources.Equipment,
+    doc_params: [
+      create:
+        ~s(%{personId: "person_abc", equipmentTypeId: "type_abc", equipmentNameId: "name_abc", serialNumber: "ABC-123"}),
+      update: ~s(%{returnedDate: "2025-12-31"})
+    ]
+
+  @type delete_response :: {:ok, %{id: String.t(), deleted: bool()}} | {:error, Humaans.Error.t()}
+  @type list_response :: {:ok, [%Humaans.Resources.Equipment{}]} | {:error, Humaans.Error.t()}
+  @type response :: {:ok, %Humaans.Resources.Equipment{}} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/equipment_names.ex
+++ b/lib/humaans/equipment_names.ex
@@ -1,0 +1,13 @@
+defmodule Humaans.EquipmentNames do
+  @moduledoc """
+  This module provides functions for listing equipment name resources in the
+  Humaans API.  Equipment names are read-only via the API.
+  """
+
+  use Humaans.Resource,
+    path: "/equipment-names",
+    struct: Humaans.Resources.EquipmentName,
+    actions: [:list]
+
+  @type list_response :: {:ok, [%Humaans.Resources.EquipmentName{}]} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/equipment_types.ex
+++ b/lib/humaans/equipment_types.ex
@@ -1,0 +1,13 @@
+defmodule Humaans.EquipmentTypes do
+  @moduledoc """
+  This module provides functions for listing equipment type resources in the
+  Humaans API.  Equipment types are read-only via the API.
+  """
+
+  use Humaans.Resource,
+    path: "/equipment-types",
+    struct: Humaans.Resources.EquipmentType,
+    actions: [:list]
+
+  @type list_response :: {:ok, [%Humaans.Resources.EquipmentType{}]} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/identity_document_types.ex
+++ b/lib/humaans/identity_document_types.ex
@@ -1,0 +1,14 @@
+defmodule Humaans.IdentityDocumentTypes do
+  @moduledoc """
+  This module provides functions for listing identity document type resources
+  in the Humaans API.  Identity document types are read-only via the API.
+  """
+
+  use Humaans.Resource,
+    path: "/identity-document-types",
+    struct: Humaans.Resources.IdentityDocumentType,
+    actions: [:list]
+
+  @type list_response ::
+          {:ok, [%Humaans.Resources.IdentityDocumentType{}]} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/identity_documents.ex
+++ b/lib/humaans/identity_documents.ex
@@ -1,0 +1,20 @@
+defmodule Humaans.IdentityDocuments do
+  @moduledoc """
+  This module provides functions for managing identity document resources in
+  the Humaans API.
+  """
+
+  use Humaans.Resource,
+    path: "/identity-documents",
+    struct: Humaans.Resources.IdentityDocument,
+    doc_params: [
+      create:
+        ~s(%{personId: "person_abc", identityDocumentTypeId: "type_abc", name: "UK Passport", number: "123456789"}),
+      update: ~s(%{number: "987654321"})
+    ]
+
+  @type delete_response :: {:ok, %{id: String.t(), deleted: bool()}} | {:error, Humaans.Error.t()}
+  @type list_response ::
+          {:ok, [%Humaans.Resources.IdentityDocument{}]} | {:error, Humaans.Error.t()}
+  @type response :: {:ok, %Humaans.Resources.IdentityDocument{}} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/public_holiday_calendar_days.ex
+++ b/lib/humaans/public_holiday_calendar_days.ex
@@ -1,0 +1,21 @@
+defmodule Humaans.PublicHolidayCalendarDays do
+  @moduledoc """
+  This module provides functions for managing public holiday calendar day
+  resources in the Humaans API.  Note that the API does not support
+  deletion.
+  """
+
+  use Humaans.Resource,
+    path: "/public-holiday-calendar-days",
+    struct: Humaans.Resources.PublicHolidayCalendarDay,
+    actions: [:list, :retrieve, :create, :update],
+    doc_params: [
+      create: ~s(%{publicHolidayCalendarId: "cal_abc", publicHolidayId: "ph_abc"}),
+      update: ~s(%{publicHolidayId: "ph_def"})
+    ]
+
+  @type list_response ::
+          {:ok, [%Humaans.Resources.PublicHolidayCalendarDay{}]} | {:error, Humaans.Error.t()}
+  @type response ::
+          {:ok, %Humaans.Resources.PublicHolidayCalendarDay{}} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/public_holiday_calendars.ex
+++ b/lib/humaans/public_holiday_calendars.ex
@@ -1,0 +1,15 @@
+defmodule Humaans.PublicHolidayCalendars do
+  @moduledoc """
+  This module provides functions for listing public holiday calendar
+  resources in the Humaans API.  Public holiday calendars are read-only via
+  the API.
+  """
+
+  use Humaans.Resource,
+    path: "/public-holiday-calendars",
+    struct: Humaans.Resources.PublicHolidayCalendar,
+    actions: [:list]
+
+  @type list_response ::
+          {:ok, [%Humaans.Resources.PublicHolidayCalendar{}]} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/public_holidays.ex
+++ b/lib/humaans/public_holidays.ex
@@ -1,0 +1,13 @@
+defmodule Humaans.PublicHolidays do
+  @moduledoc """
+  This module provides functions for listing public holiday resources in the
+  Humaans API.  Public holidays are read-only via the API.
+  """
+
+  use Humaans.Resource,
+    path: "/public-holidays",
+    struct: Humaans.Resources.PublicHoliday,
+    actions: [:list]
+
+  @type list_response :: {:ok, [%Humaans.Resources.PublicHoliday{}]} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/resources/emergency_contact.ex
+++ b/lib/humaans/resources/emergency_contact.ex
@@ -1,0 +1,38 @@
+defmodule Humaans.Resources.EmergencyContact do
+  @moduledoc """
+  Representation of an Emergency Contact resource.
+  """
+
+  defstruct [
+    :id,
+    :person_id,
+    :name,
+    :relationship,
+    :phone_number,
+    :email,
+    :created_at,
+    :updated_at
+  ]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          person_id: binary | nil,
+          name: binary | nil,
+          relationship: binary | nil,
+          phone_number: binary | nil,
+          email: binary | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/resources/equipment.ex
+++ b/lib/humaans/resources/equipment.ex
@@ -1,0 +1,42 @@
+defmodule Humaans.Resources.Equipment do
+  @moduledoc """
+  Representation of an Equipment resource.
+  """
+
+  defstruct [
+    :id,
+    :person_id,
+    :equipment_type_id,
+    :equipment_name_id,
+    :serial_number,
+    :assigned_date,
+    :returned_date,
+    :created_at,
+    :updated_at
+  ]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_date(:assigned_date)
+    |> parse_date(:returned_date)
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          person_id: binary | nil,
+          equipment_type_id: binary | nil,
+          equipment_name_id: binary | nil,
+          serial_number: binary | nil,
+          assigned_date: Date.t() | nil,
+          returned_date: Date.t() | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/resources/equipment_name.ex
+++ b/lib/humaans/resources/equipment_name.ex
@@ -1,0 +1,26 @@
+defmodule Humaans.Resources.EquipmentName do
+  @moduledoc """
+  Representation of an Equipment Name resource.
+  """
+
+  defstruct [:id, :company_id, :name, :created_at, :updated_at]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          company_id: binary | nil,
+          name: binary | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/resources/equipment_type.ex
+++ b/lib/humaans/resources/equipment_type.ex
@@ -1,0 +1,26 @@
+defmodule Humaans.Resources.EquipmentType do
+  @moduledoc """
+  Representation of an Equipment Type resource.
+  """
+
+  defstruct [:id, :company_id, :name, :created_at, :updated_at]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          company_id: binary | nil,
+          name: binary | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/resources/identity_document.ex
+++ b/lib/humaans/resources/identity_document.ex
@@ -1,0 +1,48 @@
+defmodule Humaans.Resources.IdentityDocument do
+  @moduledoc """
+  Representation of an Identity Document resource.
+  """
+
+  defstruct [
+    :id,
+    :person_id,
+    :identity_document_type_id,
+    :name,
+    :number,
+    :issuing_country,
+    :issue_date,
+    :expiry_date,
+    :file_id,
+    :file,
+    :created_at,
+    :updated_at
+  ]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_date(:issue_date)
+    |> parse_date(:expiry_date)
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          person_id: binary | nil,
+          identity_document_type_id: binary | nil,
+          name: binary | nil,
+          number: binary | nil,
+          issuing_country: binary | nil,
+          issue_date: Date.t() | nil,
+          expiry_date: Date.t() | nil,
+          file_id: binary | nil,
+          file: map | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/resources/identity_document_type.ex
+++ b/lib/humaans/resources/identity_document_type.ex
@@ -1,0 +1,26 @@
+defmodule Humaans.Resources.IdentityDocumentType do
+  @moduledoc """
+  Representation of an Identity Document Type resource.
+  """
+
+  defstruct [:id, :company_id, :name, :created_at, :updated_at]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          company_id: binary | nil,
+          name: binary | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/resources/public_holiday.ex
+++ b/lib/humaans/resources/public_holiday.ex
@@ -1,0 +1,25 @@
+defmodule Humaans.Resources.PublicHoliday do
+  @moduledoc """
+  Representation of a Public Holiday resource.
+  """
+
+  defstruct [:id, :name, :created_at, :updated_at]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          name: binary | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/resources/public_holiday_calendar.ex
+++ b/lib/humaans/resources/public_holiday_calendar.ex
@@ -1,0 +1,26 @@
+defmodule Humaans.Resources.PublicHolidayCalendar do
+  @moduledoc """
+  Representation of a Public Holiday Calendar resource.
+  """
+
+  defstruct [:id, :company_id, :name, :created_at, :updated_at]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          company_id: binary | nil,
+          name: binary | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/resources/public_holiday_calendar_day.ex
+++ b/lib/humaans/resources/public_holiday_calendar_day.ex
@@ -1,0 +1,32 @@
+defmodule Humaans.Resources.PublicHolidayCalendarDay do
+  @moduledoc """
+  Representation of a Public Holiday Calendar Day resource.
+  """
+
+  defstruct [
+    :id,
+    :public_holiday_calendar_id,
+    :public_holiday_id,
+    :created_at,
+    :updated_at
+  ]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          public_holiday_calendar_id: binary | nil,
+          public_holiday_id: binary | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/test/humaans/emergency_contacts_test.exs
+++ b/test/humaans/emergency_contacts_test.exs
@@ -1,0 +1,165 @@
+defmodule Humaans.EmergencyContactsTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.EmergencyContacts
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "list/1" do
+    test "returns a list of emergency contacts", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/emergency-contacts"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "total" => 1,
+             "limit" => 100,
+             "skip" => 0,
+             "data" => [
+               %{
+                 "id" => "ec_abc",
+                 "personId" => "person_abc",
+                 "name" => "Jane Doe",
+                 "relationship" => "Sibling",
+                 "phoneNumber" => "+44 7700 900000",
+                 "email" => "jane@example.com",
+                 "createdAt" => "2025-01-01T08:44:42.000Z",
+                 "updatedAt" => "2025-01-01T14:52:21.000Z"
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, [response]} = Humaans.EmergencyContacts.list(client)
+      assert response.id == "ec_abc"
+      assert response.person_id == "person_abc"
+      assert response.name == "Jane Doe"
+      assert response.relationship == "Sibling"
+      assert response.phone_number == "+44 7700 900000"
+      assert response.email == "jane@example.com"
+    end
+
+    test "returns error when resource is not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.EmergencyContacts.list(client)
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:error, "boom"}
+      end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.EmergencyContacts.list(client)
+    end
+  end
+
+  describe "create/2" do
+    test "creates an emergency contact", %{client: client} do
+      params = %{"personId" => "person_abc", "name" => "Jane Doe"}
+
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :method) == :post
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/emergency-contacts"
+
+        {:ok, %{status: 201, body: Map.put(params, "id", "ec_new")}}
+      end)
+
+      assert {:ok, response} = Humaans.EmergencyContacts.create(client, params)
+      assert response.id == "ec_new"
+    end
+  end
+
+  describe "retrieve/2" do
+    test "retrieves an emergency contact", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/emergency-contacts/ec_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "ec_abc",
+             "personId" => "person_abc",
+             "name" => "Jane Doe",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-01T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.EmergencyContacts.retrieve(client, "ec_abc")
+      assert response.name == "Jane Doe"
+    end
+  end
+
+  describe "update/3" do
+    test "updates an emergency contact", %{client: client} do
+      params = %{"phoneNumber" => "+44 7700 900001"}
+
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :method) == :patch
+
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/emergency-contacts/ec_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "ec_abc",
+             "phoneNumber" => "+44 7700 900001",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-02T08:44:42.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.EmergencyContacts.update(client, "ec_abc", params)
+      assert response.phone_number == "+44 7700 900001"
+    end
+  end
+
+  describe "delete/2" do
+    test "deletes an emergency contact", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :delete
+
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/emergency-contacts/ec_abc"
+
+        {:ok, %{status: 200, body: %{"id" => "ec_abc", "deleted" => true}}}
+      end)
+
+      assert {:ok, %{id: "ec_abc", deleted: true}} =
+               Humaans.EmergencyContacts.delete(client, "ec_abc")
+    end
+  end
+end

--- a/test/humaans/equipment_names_test.exs
+++ b/test/humaans/equipment_names_test.exs
@@ -1,0 +1,73 @@
+defmodule Humaans.EquipmentNamesTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.EquipmentNames
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "list/1" do
+    test "returns a list of equipment names", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/equipment-names"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "total" => 1,
+             "limit" => 100,
+             "skip" => 0,
+             "data" => [
+               %{
+                 "id" => "name_abc",
+                 "companyId" => "company_abc",
+                 "name" => "MacBook Pro",
+                 "createdAt" => "2025-01-01T08:44:42.000Z",
+                 "updatedAt" => "2025-01-01T14:52:21.000Z"
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, [response]} = Humaans.EquipmentNames.list(client)
+      assert response.name == "MacBook Pro"
+    end
+
+    test "returns error when resource is not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.EquipmentNames.list(client)
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:error, "boom"}
+      end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.EquipmentNames.list(client)
+    end
+  end
+
+  test "non-list actions are not exported" do
+    refute function_exported?(Humaans.EquipmentNames, :create, 2)
+    refute function_exported?(Humaans.EquipmentNames, :retrieve, 2)
+    refute function_exported?(Humaans.EquipmentNames, :update, 3)
+    refute function_exported?(Humaans.EquipmentNames, :delete, 2)
+  end
+end

--- a/test/humaans/equipment_test.exs
+++ b/test/humaans/equipment_test.exs
@@ -1,0 +1,164 @@
+defmodule Humaans.EquipmentTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.Equipment
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "list/1" do
+    test "returns a list of equipment", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/equipment"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "total" => 1,
+             "limit" => 100,
+             "skip" => 0,
+             "data" => [
+               %{
+                 "id" => "eq_abc",
+                 "personId" => "person_abc",
+                 "equipmentTypeId" => "type_abc",
+                 "equipmentNameId" => "name_abc",
+                 "serialNumber" => "ABC-123",
+                 "assignedDate" => "2025-01-01",
+                 "returnedDate" => nil,
+                 "createdAt" => "2025-01-01T08:44:42.000Z",
+                 "updatedAt" => "2025-01-01T14:52:21.000Z"
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, [response]} = Humaans.Equipment.list(client)
+      assert response.id == "eq_abc"
+      assert response.person_id == "person_abc"
+      assert response.equipment_type_id == "type_abc"
+      assert response.equipment_name_id == "name_abc"
+      assert response.serial_number == "ABC-123"
+      assert response.assigned_date == ~D[2025-01-01]
+      assert response.returned_date == nil
+    end
+
+    test "returns error when resource is not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.Equipment.list(client)
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:error, "boom"}
+      end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.Equipment.list(client)
+    end
+  end
+
+  describe "create/2" do
+    test "creates an equipment record", %{client: client} do
+      params = %{
+        "personId" => "person_abc",
+        "equipmentTypeId" => "type_abc",
+        "equipmentNameId" => "name_abc",
+        "serialNumber" => "ABC-123"
+      }
+
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :method) == :post
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/equipment"
+
+        {:ok, %{status: 201, body: Map.put(params, "id", "eq_new")}}
+      end)
+
+      assert {:ok, response} = Humaans.Equipment.create(client, params)
+      assert response.id == "eq_new"
+    end
+  end
+
+  describe "retrieve/2" do
+    test "retrieves an equipment record", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/equipment/eq_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "eq_abc",
+             "serialNumber" => "ABC-123",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-01T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.Equipment.retrieve(client, "eq_abc")
+      assert response.serial_number == "ABC-123"
+    end
+  end
+
+  describe "update/3" do
+    test "updates an equipment record", %{client: client} do
+      params = %{"returnedDate" => "2025-12-31"}
+
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :method) == :patch
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/equipment/eq_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "eq_abc",
+             "returnedDate" => "2025-12-31",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-02T08:44:42.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.Equipment.update(client, "eq_abc", params)
+      assert response.returned_date == ~D[2025-12-31]
+    end
+  end
+
+  describe "delete/2" do
+    test "deletes an equipment record", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :delete
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/equipment/eq_abc"
+
+        {:ok, %{status: 200, body: %{"id" => "eq_abc", "deleted" => true}}}
+      end)
+
+      assert {:ok, %{id: "eq_abc", deleted: true}} = Humaans.Equipment.delete(client, "eq_abc")
+    end
+  end
+end

--- a/test/humaans/equipment_types_test.exs
+++ b/test/humaans/equipment_types_test.exs
@@ -1,0 +1,73 @@
+defmodule Humaans.EquipmentTypesTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.EquipmentTypes
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "list/1" do
+    test "returns a list of equipment types", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/equipment-types"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "total" => 1,
+             "limit" => 100,
+             "skip" => 0,
+             "data" => [
+               %{
+                 "id" => "type_abc",
+                 "companyId" => "company_abc",
+                 "name" => "Laptop",
+                 "createdAt" => "2025-01-01T08:44:42.000Z",
+                 "updatedAt" => "2025-01-01T14:52:21.000Z"
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, [response]} = Humaans.EquipmentTypes.list(client)
+      assert response.name == "Laptop"
+    end
+
+    test "returns error when resource is not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.EquipmentTypes.list(client)
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:error, "boom"}
+      end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.EquipmentTypes.list(client)
+    end
+  end
+
+  test "non-list actions are not exported" do
+    refute function_exported?(Humaans.EquipmentTypes, :create, 2)
+    refute function_exported?(Humaans.EquipmentTypes, :retrieve, 2)
+    refute function_exported?(Humaans.EquipmentTypes, :update, 3)
+    refute function_exported?(Humaans.EquipmentTypes, :delete, 2)
+  end
+end

--- a/test/humaans/identity_document_types_test.exs
+++ b/test/humaans/identity_document_types_test.exs
@@ -1,0 +1,74 @@
+defmodule Humaans.IdentityDocumentTypesTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.IdentityDocumentTypes
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "list/1" do
+    test "returns a list of identity document types", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/identity-document-types"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "total" => 1,
+             "limit" => 100,
+             "skip" => 0,
+             "data" => [
+               %{
+                 "id" => "type_abc",
+                 "companyId" => "company_abc",
+                 "name" => "Passport",
+                 "createdAt" => "2025-01-01T08:44:42.000Z",
+                 "updatedAt" => "2025-01-01T14:52:21.000Z"
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, [response]} = Humaans.IdentityDocumentTypes.list(client)
+      assert response.id == "type_abc"
+      assert response.name == "Passport"
+    end
+
+    test "returns error when resource is not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.IdentityDocumentTypes.list(client)
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:error, "boom"}
+      end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.IdentityDocumentTypes.list(client)
+    end
+  end
+
+  test "non-list actions are not exported" do
+    refute function_exported?(Humaans.IdentityDocumentTypes, :create, 2)
+    refute function_exported?(Humaans.IdentityDocumentTypes, :retrieve, 2)
+    refute function_exported?(Humaans.IdentityDocumentTypes, :update, 3)
+    refute function_exported?(Humaans.IdentityDocumentTypes, :delete, 2)
+  end
+end

--- a/test/humaans/identity_documents_test.exs
+++ b/test/humaans/identity_documents_test.exs
@@ -1,0 +1,178 @@
+defmodule Humaans.IdentityDocumentsTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.IdentityDocuments
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "list/1" do
+    test "returns a list of identity documents", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/identity-documents"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "total" => 1,
+             "limit" => 100,
+             "skip" => 0,
+             "data" => [
+               %{
+                 "id" => "id_abc",
+                 "personId" => "person_abc",
+                 "identityDocumentTypeId" => "type_abc",
+                 "name" => "UK Passport",
+                 "number" => "123456789",
+                 "issuingCountry" => "GB",
+                 "issueDate" => "2020-01-15",
+                 "expiryDate" => "2030-01-14",
+                 "fileId" => nil,
+                 "file" => nil,
+                 "createdAt" => "2025-01-01T08:44:42.000Z",
+                 "updatedAt" => "2025-01-01T14:52:21.000Z"
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, [response]} = Humaans.IdentityDocuments.list(client)
+      assert response.id == "id_abc"
+      assert response.person_id == "person_abc"
+      assert response.identity_document_type_id == "type_abc"
+      assert response.name == "UK Passport"
+      assert response.number == "123456789"
+      assert response.issuing_country == "GB"
+      assert response.issue_date == ~D[2020-01-15]
+      assert response.expiry_date == ~D[2030-01-14]
+    end
+
+    test "returns error when resource is not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.IdentityDocuments.list(client)
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:error, "boom"}
+      end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.IdentityDocuments.list(client)
+    end
+  end
+
+  describe "create/2" do
+    test "creates an identity document", %{client: client} do
+      params = %{
+        "personId" => "person_abc",
+        "identityDocumentTypeId" => "type_abc",
+        "name" => "UK Passport",
+        "number" => "123456789"
+      }
+
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :method) == :post
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/identity-documents"
+
+        {:ok, %{status: 201, body: Map.put(params, "id", "id_new")}}
+      end)
+
+      assert {:ok, response} = Humaans.IdentityDocuments.create(client, params)
+      assert response.id == "id_new"
+      assert response.number == "123456789"
+    end
+  end
+
+  describe "retrieve/2" do
+    test "retrieves an identity document", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/identity-documents/id_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "id_abc",
+             "personId" => "person_abc",
+             "identityDocumentTypeId" => "type_abc",
+             "name" => "UK Passport",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-01T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.IdentityDocuments.retrieve(client, "id_abc")
+      assert response.name == "UK Passport"
+    end
+  end
+
+  describe "update/3" do
+    test "updates an identity document", %{client: client} do
+      params = %{"number" => "987654321"}
+
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :method) == :patch
+
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/identity-documents/id_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "id_abc",
+             "number" => "987654321",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-02T08:44:42.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.IdentityDocuments.update(client, "id_abc", params)
+      assert response.number == "987654321"
+    end
+  end
+
+  describe "delete/2" do
+    test "deletes an identity document", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :delete
+
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/identity-documents/id_abc"
+
+        {:ok, %{status: 200, body: %{"id" => "id_abc", "deleted" => true}}}
+      end)
+
+      assert {:ok, %{id: "id_abc", deleted: true}} =
+               Humaans.IdentityDocuments.delete(client, "id_abc")
+    end
+  end
+end

--- a/test/humaans/public_holiday_calendar_days_test.exs
+++ b/test/humaans/public_holiday_calendar_days_test.exs
@@ -1,0 +1,153 @@
+defmodule Humaans.PublicHolidayCalendarDaysTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.PublicHolidayCalendarDays
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "list/1" do
+    test "returns a list of public holiday calendar days", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/public-holiday-calendar-days"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "total" => 1,
+             "limit" => 100,
+             "skip" => 0,
+             "data" => [
+               %{
+                 "id" => "phcd_abc",
+                 "publicHolidayCalendarId" => "cal_abc",
+                 "publicHolidayId" => "ph_abc",
+                 "createdAt" => "2025-01-01T08:44:42.000Z",
+                 "updatedAt" => "2025-01-01T14:52:21.000Z"
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, [response]} = Humaans.PublicHolidayCalendarDays.list(client)
+      assert response.id == "phcd_abc"
+      assert response.public_holiday_calendar_id == "cal_abc"
+      assert response.public_holiday_id == "ph_abc"
+    end
+
+    test "returns error when resource is not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.PublicHolidayCalendarDays.list(client)
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:error, "boom"}
+      end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.PublicHolidayCalendarDays.list(client)
+    end
+  end
+
+  describe "create/2" do
+    test "creates a public holiday calendar day", %{client: client} do
+      params = %{"publicHolidayCalendarId" => "cal_abc", "publicHolidayId" => "ph_abc"}
+
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :method) == :post
+
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/public-holiday-calendar-days"
+
+        {:ok, %{status: 201, body: Map.put(params, "id", "phcd_new")}}
+      end)
+
+      assert {:ok, response} = Humaans.PublicHolidayCalendarDays.create(client, params)
+      assert response.id == "phcd_new"
+    end
+  end
+
+  describe "retrieve/2" do
+    test "retrieves a public holiday calendar day", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/public-holiday-calendar-days/phcd_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "phcd_abc",
+             "publicHolidayCalendarId" => "cal_abc",
+             "publicHolidayId" => "ph_abc",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-01T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.PublicHolidayCalendarDays.retrieve(client, "phcd_abc")
+      assert response.public_holiday_id == "ph_abc"
+    end
+  end
+
+  describe "update/3" do
+    test "updates a public holiday calendar day", %{client: client} do
+      params = %{"publicHolidayId" => "ph_def"}
+
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :body) == params
+        assert Keyword.fetch!(opts, :method) == :patch
+
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/public-holiday-calendar-days/phcd_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "phcd_abc",
+             "publicHolidayCalendarId" => "cal_abc",
+             "publicHolidayId" => "ph_def",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-02T08:44:42.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} =
+               Humaans.PublicHolidayCalendarDays.update(client, "phcd_abc", params)
+
+      assert response.public_holiday_id == "ph_def"
+    end
+  end
+
+  test "delete/2 is not exported" do
+    refute function_exported?(Humaans.PublicHolidayCalendarDays, :delete, 2)
+  end
+end

--- a/test/humaans/public_holiday_calendars_test.exs
+++ b/test/humaans/public_holiday_calendars_test.exs
@@ -1,0 +1,66 @@
+defmodule Humaans.PublicHolidayCalendarsTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.PublicHolidayCalendars
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "list/1" do
+    test "returns a list of public holiday calendars", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/public-holiday-calendars"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "total" => 1,
+             "limit" => 100,
+             "skip" => 0,
+             "data" => [
+               %{
+                 "id" => "cal_abc",
+                 "companyId" => "company_abc",
+                 "name" => "UK Holidays",
+                 "createdAt" => "2025-01-01T08:44:42.000Z",
+                 "updatedAt" => "2025-01-01T14:52:21.000Z"
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, [response]} = Humaans.PublicHolidayCalendars.list(client)
+      assert response.name == "UK Holidays"
+    end
+
+    test "returns error when resource is not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.PublicHolidayCalendars.list(client)
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:error, "boom"}
+      end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.PublicHolidayCalendars.list(client)
+    end
+  end
+end

--- a/test/humaans/public_holidays_test.exs
+++ b/test/humaans/public_holidays_test.exs
@@ -1,0 +1,65 @@
+defmodule Humaans.PublicHolidaysTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.PublicHolidays
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "list/1" do
+    test "returns a list of public holidays", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :method) == :get
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/public-holidays"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "total" => 1,
+             "limit" => 100,
+             "skip" => 0,
+             "data" => [
+               %{
+                 "id" => "ph_abc",
+                 "name" => "Christmas Day",
+                 "createdAt" => "2025-01-01T08:44:42.000Z",
+                 "updatedAt" => "2025-01-01T14:52:21.000Z"
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, [response]} = Humaans.PublicHolidays.list(client)
+      assert response.name == "Christmas Day"
+    end
+
+    test "returns error when resource is not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.PublicHolidays.list(client)
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:error, "boom"}
+      end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.PublicHolidays.list(client)
+    end
+  end
+end

--- a/test/humaans_test.exs
+++ b/test/humaans_test.exs
@@ -125,6 +125,10 @@ defmodule HumaansTest do
     assert Humaans.document_folders() == Humaans.DocumentFolders
   end
 
+  test "emergency_contacts/0 returns the EmergencyContacts module" do
+    assert Humaans.emergency_contacts() == Humaans.EmergencyContacts
+  end
+
   test "job_roles/0 returns the JobRoles module" do
     assert Humaans.job_roles() == Humaans.JobRoles
   end

--- a/test/humaans_test.exs
+++ b/test/humaans_test.exs
@@ -129,6 +129,18 @@ defmodule HumaansTest do
     assert Humaans.emergency_contacts() == Humaans.EmergencyContacts
   end
 
+  test "equipment/0 returns the Equipment module" do
+    assert Humaans.equipment() == Humaans.Equipment
+  end
+
+  test "equipment_types/0 returns the EquipmentTypes module" do
+    assert Humaans.equipment_types() == Humaans.EquipmentTypes
+  end
+
+  test "equipment_names/0 returns the EquipmentNames module" do
+    assert Humaans.equipment_names() == Humaans.EquipmentNames
+  end
+
   test "job_roles/0 returns the JobRoles module" do
     assert Humaans.job_roles() == Humaans.JobRoles
   end

--- a/test/humaans_test.exs
+++ b/test/humaans_test.exs
@@ -141,6 +141,14 @@ defmodule HumaansTest do
     assert Humaans.equipment_names() == Humaans.EquipmentNames
   end
 
+  test "identity_documents/0 returns the IdentityDocuments module" do
+    assert Humaans.identity_documents() == Humaans.IdentityDocuments
+  end
+
+  test "identity_document_types/0 returns the IdentityDocumentTypes module" do
+    assert Humaans.identity_document_types() == Humaans.IdentityDocumentTypes
+  end
+
   test "job_roles/0 returns the JobRoles module" do
     assert Humaans.job_roles() == Humaans.JobRoles
   end

--- a/test/humaans_test.exs
+++ b/test/humaans_test.exs
@@ -157,6 +157,18 @@ defmodule HumaansTest do
     assert Humaans.locations() == Humaans.Locations
   end
 
+  test "public_holiday_calendars/0 returns the PublicHolidayCalendars module" do
+    assert Humaans.public_holiday_calendars() == Humaans.PublicHolidayCalendars
+  end
+
+  test "public_holiday_calendar_days/0 returns the PublicHolidayCalendarDays module" do
+    assert Humaans.public_holiday_calendar_days() == Humaans.PublicHolidayCalendarDays
+  end
+
+  test "public_holidays/0 returns the PublicHolidays module" do
+    assert Humaans.public_holidays() == Humaans.PublicHolidays
+  end
+
   test "spaces/0 returns the Spaces module" do
     assert Humaans.spaces() == Humaans.Spaces
   end


### PR DESCRIPTION
:tipping_hand_person: These changes round out the employee-profile API surface with 9 resources from Group D2.

## Summary

**Full CRUD:**
- `Humaans.IdentityDocuments`: `/api/identity-documents`
- `Humaans.EmergencyContacts`: `/api/emergency-contacts`
- `Humaans.Equipment`: `/api/equipment`

**Limited operations:**
- `Humaans.PublicHolidayCalendarDays`: `/api/public-holiday-calendar-days` (list, retrieve, create, update; no delete)

**Read-only (list):**
- `Humaans.IdentityDocumentTypes`: `/api/identity-document-types`
- `Humaans.EquipmentTypes`: `/api/equipment-types`
- `Humaans.EquipmentNames`: `/api/equipment-names`
- `Humaans.PublicHolidayCalendars`: `/api/public-holiday-calendars`
- `Humaans.PublicHolidays`: `/api/public-holidays`

Each resource ships as struct + module + tests using `Humaans.Resource`. Modules with restricted action sets declare `actions: [...]` explicitly and include guard tests confirming non-exported functions stay unexported.

Module access helpers and README updated.

## Test plan

- [x] `mix test` passes (~37 new tests)
- [x] `mix credo` clean
- [x] `mix format --check-formatted` clean