### PR TITLE
feat(performance): add Performance family read-only resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,13 @@ Supported operators: `eq`, `in_`, `nin`, `gt`, `gte`, `lt`, `lte`. Use `Humaans.
 - `Humaans.Locations` - Work with location resources
 - `Humaans.Me` - Retrieve the authenticated user's profile (`GET /me`)
 - `Humaans.OKRs` - List and retrieve OKR resources (read-only)
+- `Humaans.PerformanceCyclePeerNominations` - Retrieve peer nomination resources (read-only)
+- `Humaans.PerformanceCycles` - List and retrieve performance cycle resources (read-only)
+- `Humaans.PerformanceInstances` - List and retrieve performance instance resources (read-only)
+- `Humaans.PerformanceRatings` - Retrieve performance rating resources (read-only)
+- `Humaans.PerformanceReviews` - List and retrieve performance review resources (read-only)
+- `Humaans.PerformanceSummaries` - Retrieve performance summary resources (read-only)
+- `Humaans.PerformanceTemplates` - List and retrieve performance template resources (read-only)
 - `Humaans.PublicHolidayCalendarDays` - Work with public holiday calendar day resources
 - `Humaans.PublicHolidayCalendars` - List public holiday calendars (read-only)
 - `Humaans.PublicHolidays` - List public holidays (read-only)

--- a/lib/humaans.ex
+++ b/lib/humaans.ex
@@ -292,6 +292,55 @@ defmodule Humaans do
   def pagination, do: Humaans.Pagination
 
   @doc """
+  Access the Performance Cycles API.
+
+  Returns the module that contains functions for working with performance cycle resources.
+  """
+  def performance_cycles, do: Humaans.PerformanceCycles
+
+  @doc """
+  Access the Performance Templates API.
+
+  Returns the module that contains functions for working with performance template resources.
+  """
+  def performance_templates, do: Humaans.PerformanceTemplates
+
+  @doc """
+  Access the Performance Reviews API.
+
+  Returns the module that contains functions for working with performance review resources.
+  """
+  def performance_reviews, do: Humaans.PerformanceReviews
+
+  @doc """
+  Access the Performance Instances API.
+
+  Returns the module that contains functions for working with performance instance resources.
+  """
+  def performance_instances, do: Humaans.PerformanceInstances
+
+  @doc """
+  Access the Performance Ratings API.
+
+  Returns the module that contains functions for working with performance rating resources.
+  """
+  def performance_ratings, do: Humaans.PerformanceRatings
+
+  @doc """
+  Access the Performance Summaries API.
+
+  Returns the module that contains functions for working with performance summary resources.
+  """
+  def performance_summaries, do: Humaans.PerformanceSummaries
+
+  @doc """
+  Access the Performance Cycle Peer Nominations API.
+
+  Returns the module that contains functions for working with peer nomination resources.
+  """
+  def performance_cycle_peer_nominations, do: Humaans.PerformanceCyclePeerNominations
+
+  @doc """
   Access the People API.
 
   Returns the module that contains functions for working with people resources.

--- a/lib/humaans/performance_cycle_peer_nominations.ex
+++ b/lib/humaans/performance_cycle_peer_nominations.ex
@@ -1,0 +1,16 @@
+defmodule Humaans.PerformanceCyclePeerNominations do
+  @moduledoc """
+  This module provides functions for retrieving performance cycle peer
+  nomination resources in the Humaans API.  Peer nominations are
+  retrieve-only via the API.
+  """
+
+  use Humaans.Resource,
+    path: "/performance-cycle-peer-nominations",
+    struct: Humaans.Resources.PerformanceCyclePeerNomination,
+    actions: [:retrieve]
+
+  @type response ::
+          {:ok, %Humaans.Resources.PerformanceCyclePeerNomination{}}
+          | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/performance_cycles.ex
+++ b/lib/humaans/performance_cycles.ex
@@ -1,0 +1,16 @@
+defmodule Humaans.PerformanceCycles do
+  @moduledoc """
+  This module provides functions for listing and retrieving performance
+  cycle resources in the Humaans API.  Performance cycles are read-only
+  via the API.
+  """
+
+  use Humaans.Resource,
+    path: "/performance-cycles",
+    struct: Humaans.Resources.PerformanceCycle,
+    actions: [:list, :retrieve]
+
+  @type list_response ::
+          {:ok, [%Humaans.Resources.PerformanceCycle{}]} | {:error, Humaans.Error.t()}
+  @type response :: {:ok, %Humaans.Resources.PerformanceCycle{}} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/performance_instances.ex
+++ b/lib/humaans/performance_instances.ex
@@ -1,0 +1,16 @@
+defmodule Humaans.PerformanceInstances do
+  @moduledoc """
+  This module provides functions for listing and retrieving performance
+  instance resources in the Humaans API.  Performance instances are
+  read-only via the API.
+  """
+
+  use Humaans.Resource,
+    path: "/performance-instances",
+    struct: Humaans.Resources.PerformanceInstance,
+    actions: [:list, :retrieve]
+
+  @type list_response ::
+          {:ok, [%Humaans.Resources.PerformanceInstance{}]} | {:error, Humaans.Error.t()}
+  @type response :: {:ok, %Humaans.Resources.PerformanceInstance{}} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/performance_ratings.ex
+++ b/lib/humaans/performance_ratings.ex
@@ -1,0 +1,14 @@
+defmodule Humaans.PerformanceRatings do
+  @moduledoc """
+  This module provides functions for retrieving performance rating
+  resources in the Humaans API.  Performance ratings are retrieve-only via
+  the API.
+  """
+
+  use Humaans.Resource,
+    path: "/performance-ratings",
+    struct: Humaans.Resources.PerformanceRating,
+    actions: [:retrieve]
+
+  @type response :: {:ok, %Humaans.Resources.PerformanceRating{}} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/performance_reviews.ex
+++ b/lib/humaans/performance_reviews.ex
@@ -1,0 +1,16 @@
+defmodule Humaans.PerformanceReviews do
+  @moduledoc """
+  This module provides functions for listing and retrieving performance
+  review resources in the Humaans API.  Performance reviews are read-only
+  via the API.
+  """
+
+  use Humaans.Resource,
+    path: "/performance-reviews",
+    struct: Humaans.Resources.PerformanceReview,
+    actions: [:list, :retrieve]
+
+  @type list_response ::
+          {:ok, [%Humaans.Resources.PerformanceReview{}]} | {:error, Humaans.Error.t()}
+  @type response :: {:ok, %Humaans.Resources.PerformanceReview{}} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/performance_summaries.ex
+++ b/lib/humaans/performance_summaries.ex
@@ -1,0 +1,14 @@
+defmodule Humaans.PerformanceSummaries do
+  @moduledoc """
+  This module provides functions for retrieving performance summary
+  resources in the Humaans API.  Performance summaries are retrieve-only
+  via the API.
+  """
+
+  use Humaans.Resource,
+    path: "/performance-summaries",
+    struct: Humaans.Resources.PerformanceSummary,
+    actions: [:retrieve]
+
+  @type response :: {:ok, %Humaans.Resources.PerformanceSummary{}} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/performance_templates.ex
+++ b/lib/humaans/performance_templates.ex
@@ -1,0 +1,16 @@
+defmodule Humaans.PerformanceTemplates do
+  @moduledoc """
+  This module provides functions for listing and retrieving performance
+  template resources in the Humaans API.  Performance templates are
+  read-only via the API.
+  """
+
+  use Humaans.Resource,
+    path: "/performance-templates",
+    struct: Humaans.Resources.PerformanceTemplate,
+    actions: [:list, :retrieve]
+
+  @type list_response ::
+          {:ok, [%Humaans.Resources.PerformanceTemplate{}]} | {:error, Humaans.Error.t()}
+  @type response :: {:ok, %Humaans.Resources.PerformanceTemplate{}} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/resources/performance_cycle.ex
+++ b/lib/humaans/resources/performance_cycle.ex
@@ -1,0 +1,40 @@
+defmodule Humaans.Resources.PerformanceCycle do
+  @moduledoc """
+  Representation of a Performance Cycle resource.
+  """
+
+  defstruct [
+    :id,
+    :company_id,
+    :name,
+    :status,
+    :start_date,
+    :end_date,
+    :created_at,
+    :updated_at
+  ]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_date(:start_date)
+    |> parse_date(:end_date)
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          company_id: binary | nil,
+          name: binary | nil,
+          status: binary | nil,
+          start_date: Date.t() | nil,
+          end_date: Date.t() | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/resources/performance_cycle_peer_nomination.ex
+++ b/lib/humaans/resources/performance_cycle_peer_nomination.ex
@@ -1,0 +1,38 @@
+defmodule Humaans.Resources.PerformanceCyclePeerNomination do
+  @moduledoc """
+  Representation of a Performance Cycle Peer Nomination resource.
+  """
+
+  defstruct [
+    :id,
+    :company_id,
+    :performance_cycle_id,
+    :person_id,
+    :nominee_id,
+    :status,
+    :created_at,
+    :updated_at
+  ]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          company_id: binary | nil,
+          performance_cycle_id: binary | nil,
+          person_id: binary | nil,
+          nominee_id: binary | nil,
+          status: binary | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/resources/performance_instance.ex
+++ b/lib/humaans/resources/performance_instance.ex
@@ -1,0 +1,36 @@
+defmodule Humaans.Resources.PerformanceInstance do
+  @moduledoc """
+  Representation of a Performance Instance resource.
+  """
+
+  defstruct [
+    :id,
+    :company_id,
+    :performance_cycle_id,
+    :person_id,
+    :status,
+    :created_at,
+    :updated_at
+  ]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          company_id: binary | nil,
+          performance_cycle_id: binary | nil,
+          person_id: binary | nil,
+          status: binary | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/resources/performance_rating.ex
+++ b/lib/humaans/resources/performance_rating.ex
@@ -1,0 +1,34 @@
+defmodule Humaans.Resources.PerformanceRating do
+  @moduledoc """
+  Representation of a Performance Rating resource.
+  """
+
+  defstruct [
+    :id,
+    :company_id,
+    :person_id,
+    :value,
+    :created_at,
+    :updated_at
+  ]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          company_id: binary | nil,
+          person_id: binary | nil,
+          value: any | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/resources/performance_review.ex
+++ b/lib/humaans/resources/performance_review.ex
@@ -1,0 +1,36 @@
+defmodule Humaans.Resources.PerformanceReview do
+  @moduledoc """
+  Representation of a Performance Review resource.
+  """
+
+  defstruct [
+    :id,
+    :company_id,
+    :person_id,
+    :performance_instance_id,
+    :status,
+    :created_at,
+    :updated_at
+  ]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          company_id: binary | nil,
+          person_id: binary | nil,
+          performance_instance_id: binary | nil,
+          status: binary | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/resources/performance_summary.ex
+++ b/lib/humaans/resources/performance_summary.ex
@@ -1,0 +1,36 @@
+defmodule Humaans.Resources.PerformanceSummary do
+  @moduledoc """
+  Representation of a Performance Summary resource.
+  """
+
+  defstruct [
+    :id,
+    :company_id,
+    :person_id,
+    :performance_cycle_id,
+    :summary,
+    :created_at,
+    :updated_at
+  ]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          company_id: binary | nil,
+          person_id: binary | nil,
+          performance_cycle_id: binary | nil,
+          summary: any | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/resources/performance_template.ex
+++ b/lib/humaans/resources/performance_template.ex
@@ -1,0 +1,26 @@
+defmodule Humaans.Resources.PerformanceTemplate do
+  @moduledoc """
+  Representation of a Performance Template resource.
+  """
+
+  defstruct [:id, :company_id, :name, :created_at, :updated_at]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          company_id: binary | nil,
+          name: binary | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/test/humaans/performance_cycle_peer_nominations_test.exs
+++ b/test/humaans/performance_cycle_peer_nominations_test.exs
@@ -1,0 +1,67 @@
+defmodule Humaans.PerformanceCyclePeerNominationsTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.PerformanceCyclePeerNominations
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "retrieve/2" do
+    test "retrieves a performance cycle peer nomination", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/performance-cycle-peer-nominations/pcpn_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "pcpn_abc",
+             "companyId" => "company_abc",
+             "performanceCycleId" => "pc_abc",
+             "personId" => "person_abc",
+             "nomineeId" => "person_def",
+             "status" => "approved",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-01T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} =
+               Humaans.PerformanceCyclePeerNominations.retrieve(client, "pcpn_abc")
+
+      assert response.id == "pcpn_abc"
+      assert response.nominee_id == "person_def"
+    end
+
+    test "returns error when not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ ->
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.PerformanceCyclePeerNominations.retrieve(client, "missing")
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ -> {:error, "boom"} end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.PerformanceCyclePeerNominations.retrieve(client, "pcpn_abc")
+    end
+  end
+
+  test "non-retrieve actions are not exported" do
+    refute function_exported?(Humaans.PerformanceCyclePeerNominations, :list, 2)
+    refute function_exported?(Humaans.PerformanceCyclePeerNominations, :create, 2)
+    refute function_exported?(Humaans.PerformanceCyclePeerNominations, :update, 3)
+    refute function_exported?(Humaans.PerformanceCyclePeerNominations, :delete, 2)
+  end
+end

--- a/test/humaans/performance_cycle_peer_nominations_test.exs
+++ b/test/humaans/performance_cycle_peer_nominations_test.exs
@@ -14,7 +14,11 @@ defmodule Humaans.PerformanceCyclePeerNominationsTest do
 
   describe "retrieve/2" do
     test "retrieves a performance cycle peer nomination", %{client: client} do
-      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
+        assert Keyword.fetch!(opts, :method) == :get
+
         assert Keyword.fetch!(opts, :url) ==
                  "https://app.humaans.io/api/performance-cycle-peer-nominations/pcpn_abc"
 
@@ -38,11 +42,18 @@ defmodule Humaans.PerformanceCyclePeerNominationsTest do
                Humaans.PerformanceCyclePeerNominations.retrieve(client, "pcpn_abc")
 
       assert response.id == "pcpn_abc"
+      assert response.company_id == "company_abc"
+      assert response.performance_cycle_id == "pc_abc"
+      assert response.person_id == "person_abc"
       assert response.nominee_id == "person_def"
+      assert response.status == "approved"
+      assert response.created_at == ~U[2025-01-01 08:44:42.000Z]
+      assert response.updated_at == ~U[2025-01-01 14:52:21.000Z]
     end
 
     test "returns error when not found", %{client: client} do
-      expect(Humaans.MockHTTPClient, :request, fn _, _ ->
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
         {:ok, %{status: 404, body: %{"error" => "Not found"}}}
       end)
 
@@ -51,7 +62,10 @@ defmodule Humaans.PerformanceCyclePeerNominationsTest do
     end
 
     test "returns error when request fails", %{client: client} do
-      expect(Humaans.MockHTTPClient, :request, fn _, _ -> {:error, "boom"} end)
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:error, "boom"}
+      end)
 
       assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
                Humaans.PerformanceCyclePeerNominations.retrieve(client, "pcpn_abc")

--- a/test/humaans/performance_cycles_test.exs
+++ b/test/humaans/performance_cycles_test.exs
@@ -1,0 +1,96 @@
+defmodule Humaans.PerformanceCyclesTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.PerformanceCycles
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "list/1" do
+    test "returns a list of performance cycles", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/performance-cycles"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "total" => 1,
+             "limit" => 100,
+             "skip" => 0,
+             "data" => [
+               %{
+                 "id" => "pc_abc",
+                 "companyId" => "company_abc",
+                 "name" => "Q1 2025",
+                 "status" => "open",
+                 "startDate" => "2025-01-01",
+                 "endDate" => "2025-03-31",
+                 "createdAt" => "2025-01-01T08:44:42.000Z",
+                 "updatedAt" => "2025-01-01T14:52:21.000Z"
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, [response]} = Humaans.PerformanceCycles.list(client)
+      assert response.id == "pc_abc"
+      assert response.name == "Q1 2025"
+      assert response.status == "open"
+      assert response.start_date == ~D[2025-01-01]
+      assert response.end_date == ~D[2025-03-31]
+    end
+
+    test "returns error when not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ ->
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.PerformanceCycles.list(client)
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ -> {:error, "boom"} end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.PerformanceCycles.list(client)
+    end
+  end
+
+  describe "retrieve/2" do
+    test "retrieves a performance cycle", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/performance-cycles/pc_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "pc_abc",
+             "name" => "Q1 2025",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-01T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.PerformanceCycles.retrieve(client, "pc_abc")
+      assert response.name == "Q1 2025"
+    end
+  end
+
+  test "write actions are not exported" do
+    refute function_exported?(Humaans.PerformanceCycles, :create, 2)
+    refute function_exported?(Humaans.PerformanceCycles, :update, 3)
+    refute function_exported?(Humaans.PerformanceCycles, :delete, 2)
+  end
+end

--- a/test/humaans/performance_cycles_test.exs
+++ b/test/humaans/performance_cycles_test.exs
@@ -14,7 +14,10 @@ defmodule Humaans.PerformanceCyclesTest do
 
   describe "list/1" do
     test "returns a list of performance cycles", %{client: client} do
-      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
+        assert Keyword.fetch!(opts, :method) == :get
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/performance-cycles"
 
         {:ok,
@@ -42,14 +45,18 @@ defmodule Humaans.PerformanceCyclesTest do
 
       assert {:ok, [response]} = Humaans.PerformanceCycles.list(client)
       assert response.id == "pc_abc"
+      assert response.company_id == "company_abc"
       assert response.name == "Q1 2025"
       assert response.status == "open"
       assert response.start_date == ~D[2025-01-01]
       assert response.end_date == ~D[2025-03-31]
+      assert response.created_at == ~U[2025-01-01 08:44:42.000Z]
+      assert response.updated_at == ~U[2025-01-01 14:52:21.000Z]
     end
 
     test "returns error when not found", %{client: client} do
-      expect(Humaans.MockHTTPClient, :request, fn _, _ ->
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
         {:ok, %{status: 404, body: %{"error" => "Not found"}}}
       end)
 
@@ -58,7 +65,10 @@ defmodule Humaans.PerformanceCyclesTest do
     end
 
     test "returns error when request fails", %{client: client} do
-      expect(Humaans.MockHTTPClient, :request, fn _, _ -> {:error, "boom"} end)
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:error, "boom"}
+      end)
 
       assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
                Humaans.PerformanceCycles.list(client)
@@ -67,7 +77,11 @@ defmodule Humaans.PerformanceCyclesTest do
 
   describe "retrieve/2" do
     test "retrieves a performance cycle", %{client: client} do
-      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
+        assert Keyword.fetch!(opts, :method) == :get
+
         assert Keyword.fetch!(opts, :url) ==
                  "https://app.humaans.io/api/performance-cycles/pc_abc"
 
@@ -76,7 +90,11 @@ defmodule Humaans.PerformanceCyclesTest do
            status: 200,
            body: %{
              "id" => "pc_abc",
+             "companyId" => "company_abc",
              "name" => "Q1 2025",
+             "status" => "open",
+             "startDate" => "2025-01-01",
+             "endDate" => "2025-03-31",
              "createdAt" => "2025-01-01T08:44:42.000Z",
              "updatedAt" => "2025-01-01T14:52:21.000Z"
            }
@@ -84,7 +102,14 @@ defmodule Humaans.PerformanceCyclesTest do
       end)
 
       assert {:ok, response} = Humaans.PerformanceCycles.retrieve(client, "pc_abc")
+      assert response.id == "pc_abc"
+      assert response.company_id == "company_abc"
       assert response.name == "Q1 2025"
+      assert response.status == "open"
+      assert response.start_date == ~D[2025-01-01]
+      assert response.end_date == ~D[2025-03-31]
+      assert response.created_at == ~U[2025-01-01 08:44:42.000Z]
+      assert response.updated_at == ~U[2025-01-01 14:52:21.000Z]
     end
   end
 

--- a/test/humaans/performance_instances_test.exs
+++ b/test/humaans/performance_instances_test.exs
@@ -1,0 +1,93 @@
+defmodule Humaans.PerformanceInstancesTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.PerformanceInstances
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "list/1" do
+    test "returns a list of performance instances", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/performance-instances"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "total" => 1,
+             "limit" => 100,
+             "skip" => 0,
+             "data" => [
+               %{
+                 "id" => "pi_abc",
+                 "companyId" => "company_abc",
+                 "performanceCycleId" => "pc_abc",
+                 "personId" => "person_abc",
+                 "status" => "open",
+                 "createdAt" => "2025-01-01T08:44:42.000Z",
+                 "updatedAt" => "2025-01-01T14:52:21.000Z"
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, [response]} = Humaans.PerformanceInstances.list(client)
+      assert response.id == "pi_abc"
+      assert response.performance_cycle_id == "pc_abc"
+      assert response.person_id == "person_abc"
+    end
+
+    test "returns error when not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ ->
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.PerformanceInstances.list(client)
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ -> {:error, "boom"} end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.PerformanceInstances.list(client)
+    end
+  end
+
+  describe "retrieve/2" do
+    test "retrieves a performance instance", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/performance-instances/pi_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "pi_abc",
+             "performanceCycleId" => "pc_abc",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-01T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.PerformanceInstances.retrieve(client, "pi_abc")
+      assert response.performance_cycle_id == "pc_abc"
+    end
+  end
+
+  test "write actions are not exported" do
+    refute function_exported?(Humaans.PerformanceInstances, :create, 2)
+    refute function_exported?(Humaans.PerformanceInstances, :update, 3)
+    refute function_exported?(Humaans.PerformanceInstances, :delete, 2)
+  end
+end

--- a/test/humaans/performance_instances_test.exs
+++ b/test/humaans/performance_instances_test.exs
@@ -14,7 +14,10 @@ defmodule Humaans.PerformanceInstancesTest do
 
   describe "list/1" do
     test "returns a list of performance instances", %{client: client} do
-      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
+        assert Keyword.fetch!(opts, :method) == :get
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/performance-instances"
 
         {:ok,
@@ -41,12 +44,17 @@ defmodule Humaans.PerformanceInstancesTest do
 
       assert {:ok, [response]} = Humaans.PerformanceInstances.list(client)
       assert response.id == "pi_abc"
+      assert response.company_id == "company_abc"
       assert response.performance_cycle_id == "pc_abc"
       assert response.person_id == "person_abc"
+      assert response.status == "open"
+      assert response.created_at == ~U[2025-01-01 08:44:42.000Z]
+      assert response.updated_at == ~U[2025-01-01 14:52:21.000Z]
     end
 
     test "returns error when not found", %{client: client} do
-      expect(Humaans.MockHTTPClient, :request, fn _, _ ->
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
         {:ok, %{status: 404, body: %{"error" => "Not found"}}}
       end)
 
@@ -55,7 +63,10 @@ defmodule Humaans.PerformanceInstancesTest do
     end
 
     test "returns error when request fails", %{client: client} do
-      expect(Humaans.MockHTTPClient, :request, fn _, _ -> {:error, "boom"} end)
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:error, "boom"}
+      end)
 
       assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
                Humaans.PerformanceInstances.list(client)
@@ -64,7 +75,11 @@ defmodule Humaans.PerformanceInstancesTest do
 
   describe "retrieve/2" do
     test "retrieves a performance instance", %{client: client} do
-      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
+        assert Keyword.fetch!(opts, :method) == :get
+
         assert Keyword.fetch!(opts, :url) ==
                  "https://app.humaans.io/api/performance-instances/pi_abc"
 
@@ -73,7 +88,10 @@ defmodule Humaans.PerformanceInstancesTest do
            status: 200,
            body: %{
              "id" => "pi_abc",
+             "companyId" => "company_abc",
              "performanceCycleId" => "pc_abc",
+             "personId" => "person_abc",
+             "status" => "open",
              "createdAt" => "2025-01-01T08:44:42.000Z",
              "updatedAt" => "2025-01-01T14:52:21.000Z"
            }
@@ -81,7 +99,13 @@ defmodule Humaans.PerformanceInstancesTest do
       end)
 
       assert {:ok, response} = Humaans.PerformanceInstances.retrieve(client, "pi_abc")
+      assert response.id == "pi_abc"
+      assert response.company_id == "company_abc"
       assert response.performance_cycle_id == "pc_abc"
+      assert response.person_id == "person_abc"
+      assert response.status == "open"
+      assert response.created_at == ~U[2025-01-01 08:44:42.000Z]
+      assert response.updated_at == ~U[2025-01-01 14:52:21.000Z]
     end
   end
 

--- a/test/humaans/performance_ratings_test.exs
+++ b/test/humaans/performance_ratings_test.exs
@@ -1,0 +1,62 @@
+defmodule Humaans.PerformanceRatingsTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.PerformanceRatings
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "retrieve/2" do
+    test "retrieves a performance rating", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/performance-ratings/prt_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "prt_abc",
+             "companyId" => "company_abc",
+             "personId" => "person_abc",
+             "value" => 5,
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-01T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.PerformanceRatings.retrieve(client, "prt_abc")
+      assert response.value == 5
+    end
+
+    test "returns error when not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ ->
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.PerformanceRatings.retrieve(client, "missing")
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ -> {:error, "boom"} end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.PerformanceRatings.retrieve(client, "prt_abc")
+    end
+  end
+
+  test "non-retrieve actions are not exported" do
+    refute function_exported?(Humaans.PerformanceRatings, :list, 2)
+    refute function_exported?(Humaans.PerformanceRatings, :create, 2)
+    refute function_exported?(Humaans.PerformanceRatings, :update, 3)
+    refute function_exported?(Humaans.PerformanceRatings, :delete, 2)
+  end
+end

--- a/test/humaans/performance_ratings_test.exs
+++ b/test/humaans/performance_ratings_test.exs
@@ -14,7 +14,11 @@ defmodule Humaans.PerformanceRatingsTest do
 
   describe "retrieve/2" do
     test "retrieves a performance rating", %{client: client} do
-      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
+        assert Keyword.fetch!(opts, :method) == :get
+
         assert Keyword.fetch!(opts, :url) ==
                  "https://app.humaans.io/api/performance-ratings/prt_abc"
 
@@ -33,11 +37,17 @@ defmodule Humaans.PerformanceRatingsTest do
       end)
 
       assert {:ok, response} = Humaans.PerformanceRatings.retrieve(client, "prt_abc")
+      assert response.id == "prt_abc"
+      assert response.company_id == "company_abc"
+      assert response.person_id == "person_abc"
       assert response.value == 5
+      assert response.created_at == ~U[2025-01-01 08:44:42.000Z]
+      assert response.updated_at == ~U[2025-01-01 14:52:21.000Z]
     end
 
     test "returns error when not found", %{client: client} do
-      expect(Humaans.MockHTTPClient, :request, fn _, _ ->
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
         {:ok, %{status: 404, body: %{"error" => "Not found"}}}
       end)
 
@@ -46,7 +56,10 @@ defmodule Humaans.PerformanceRatingsTest do
     end
 
     test "returns error when request fails", %{client: client} do
-      expect(Humaans.MockHTTPClient, :request, fn _, _ -> {:error, "boom"} end)
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:error, "boom"}
+      end)
 
       assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
                Humaans.PerformanceRatings.retrieve(client, "prt_abc")

--- a/test/humaans/performance_reviews_test.exs
+++ b/test/humaans/performance_reviews_test.exs
@@ -1,0 +1,93 @@
+defmodule Humaans.PerformanceReviewsTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.PerformanceReviews
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "list/1" do
+    test "returns a list of performance reviews", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/performance-reviews"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "total" => 1,
+             "limit" => 100,
+             "skip" => 0,
+             "data" => [
+               %{
+                 "id" => "pr_abc",
+                 "companyId" => "company_abc",
+                 "personId" => "person_abc",
+                 "performanceInstanceId" => "pi_abc",
+                 "status" => "submitted",
+                 "createdAt" => "2025-01-01T08:44:42.000Z",
+                 "updatedAt" => "2025-01-01T14:52:21.000Z"
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, [response]} = Humaans.PerformanceReviews.list(client)
+      assert response.id == "pr_abc"
+      assert response.performance_instance_id == "pi_abc"
+      assert response.status == "submitted"
+    end
+
+    test "returns error when not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ ->
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.PerformanceReviews.list(client)
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ -> {:error, "boom"} end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.PerformanceReviews.list(client)
+    end
+  end
+
+  describe "retrieve/2" do
+    test "retrieves a performance review", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/performance-reviews/pr_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "pr_abc",
+             "performanceInstanceId" => "pi_abc",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-01T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.PerformanceReviews.retrieve(client, "pr_abc")
+      assert response.performance_instance_id == "pi_abc"
+    end
+  end
+
+  test "write actions are not exported" do
+    refute function_exported?(Humaans.PerformanceReviews, :create, 2)
+    refute function_exported?(Humaans.PerformanceReviews, :update, 3)
+    refute function_exported?(Humaans.PerformanceReviews, :delete, 2)
+  end
+end

--- a/test/humaans/performance_reviews_test.exs
+++ b/test/humaans/performance_reviews_test.exs
@@ -14,7 +14,10 @@ defmodule Humaans.PerformanceReviewsTest do
 
   describe "list/1" do
     test "returns a list of performance reviews", %{client: client} do
-      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
+        assert Keyword.fetch!(opts, :method) == :get
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/performance-reviews"
 
         {:ok,
@@ -41,12 +44,17 @@ defmodule Humaans.PerformanceReviewsTest do
 
       assert {:ok, [response]} = Humaans.PerformanceReviews.list(client)
       assert response.id == "pr_abc"
+      assert response.company_id == "company_abc"
+      assert response.person_id == "person_abc"
       assert response.performance_instance_id == "pi_abc"
       assert response.status == "submitted"
+      assert response.created_at == ~U[2025-01-01 08:44:42.000Z]
+      assert response.updated_at == ~U[2025-01-01 14:52:21.000Z]
     end
 
     test "returns error when not found", %{client: client} do
-      expect(Humaans.MockHTTPClient, :request, fn _, _ ->
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
         {:ok, %{status: 404, body: %{"error" => "Not found"}}}
       end)
 
@@ -55,7 +63,10 @@ defmodule Humaans.PerformanceReviewsTest do
     end
 
     test "returns error when request fails", %{client: client} do
-      expect(Humaans.MockHTTPClient, :request, fn _, _ -> {:error, "boom"} end)
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:error, "boom"}
+      end)
 
       assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
                Humaans.PerformanceReviews.list(client)
@@ -64,7 +75,11 @@ defmodule Humaans.PerformanceReviewsTest do
 
   describe "retrieve/2" do
     test "retrieves a performance review", %{client: client} do
-      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
+        assert Keyword.fetch!(opts, :method) == :get
+
         assert Keyword.fetch!(opts, :url) ==
                  "https://app.humaans.io/api/performance-reviews/pr_abc"
 
@@ -73,7 +88,10 @@ defmodule Humaans.PerformanceReviewsTest do
            status: 200,
            body: %{
              "id" => "pr_abc",
+             "companyId" => "company_abc",
+             "personId" => "person_abc",
              "performanceInstanceId" => "pi_abc",
+             "status" => "submitted",
              "createdAt" => "2025-01-01T08:44:42.000Z",
              "updatedAt" => "2025-01-01T14:52:21.000Z"
            }
@@ -81,7 +99,13 @@ defmodule Humaans.PerformanceReviewsTest do
       end)
 
       assert {:ok, response} = Humaans.PerformanceReviews.retrieve(client, "pr_abc")
+      assert response.id == "pr_abc"
+      assert response.company_id == "company_abc"
+      assert response.person_id == "person_abc"
       assert response.performance_instance_id == "pi_abc"
+      assert response.status == "submitted"
+      assert response.created_at == ~U[2025-01-01 08:44:42.000Z]
+      assert response.updated_at == ~U[2025-01-01 14:52:21.000Z]
     end
   end
 

--- a/test/humaans/performance_summaries_test.exs
+++ b/test/humaans/performance_summaries_test.exs
@@ -1,0 +1,64 @@
+defmodule Humaans.PerformanceSummariesTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.PerformanceSummaries
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "retrieve/2" do
+    test "retrieves a performance summary", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/performance-summaries/ps_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "ps_abc",
+             "companyId" => "company_abc",
+             "personId" => "person_abc",
+             "performanceCycleId" => "pc_abc",
+             "summary" => "Strong performer this cycle.",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-01T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.PerformanceSummaries.retrieve(client, "ps_abc")
+      assert response.id == "ps_abc"
+      assert response.summary == "Strong performer this cycle."
+    end
+
+    test "returns error when not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ ->
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.PerformanceSummaries.retrieve(client, "missing")
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ -> {:error, "boom"} end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.PerformanceSummaries.retrieve(client, "ps_abc")
+    end
+  end
+
+  test "non-retrieve actions are not exported" do
+    refute function_exported?(Humaans.PerformanceSummaries, :list, 2)
+    refute function_exported?(Humaans.PerformanceSummaries, :create, 2)
+    refute function_exported?(Humaans.PerformanceSummaries, :update, 3)
+    refute function_exported?(Humaans.PerformanceSummaries, :delete, 2)
+  end
+end

--- a/test/humaans/performance_summaries_test.exs
+++ b/test/humaans/performance_summaries_test.exs
@@ -14,7 +14,11 @@ defmodule Humaans.PerformanceSummariesTest do
 
   describe "retrieve/2" do
     test "retrieves a performance summary", %{client: client} do
-      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
+        assert Keyword.fetch!(opts, :method) == :get
+
         assert Keyword.fetch!(opts, :url) ==
                  "https://app.humaans.io/api/performance-summaries/ps_abc"
 
@@ -35,11 +39,17 @@ defmodule Humaans.PerformanceSummariesTest do
 
       assert {:ok, response} = Humaans.PerformanceSummaries.retrieve(client, "ps_abc")
       assert response.id == "ps_abc"
+      assert response.company_id == "company_abc"
+      assert response.person_id == "person_abc"
+      assert response.performance_cycle_id == "pc_abc"
       assert response.summary == "Strong performer this cycle."
+      assert response.created_at == ~U[2025-01-01 08:44:42.000Z]
+      assert response.updated_at == ~U[2025-01-01 14:52:21.000Z]
     end
 
     test "returns error when not found", %{client: client} do
-      expect(Humaans.MockHTTPClient, :request, fn _, _ ->
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
         {:ok, %{status: 404, body: %{"error" => "Not found"}}}
       end)
 
@@ -48,7 +58,10 @@ defmodule Humaans.PerformanceSummariesTest do
     end
 
     test "returns error when request fails", %{client: client} do
-      expect(Humaans.MockHTTPClient, :request, fn _, _ -> {:error, "boom"} end)
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:error, "boom"}
+      end)
 
       assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
                Humaans.PerformanceSummaries.retrieve(client, "ps_abc")

--- a/test/humaans/performance_templates_test.exs
+++ b/test/humaans/performance_templates_test.exs
@@ -1,0 +1,89 @@
+defmodule Humaans.PerformanceTemplatesTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.PerformanceTemplates
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "list/1" do
+    test "returns a list of performance templates", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/performance-templates"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "total" => 1,
+             "limit" => 100,
+             "skip" => 0,
+             "data" => [
+               %{
+                 "id" => "pt_abc",
+                 "companyId" => "company_abc",
+                 "name" => "Engineering Review",
+                 "createdAt" => "2025-01-01T08:44:42.000Z",
+                 "updatedAt" => "2025-01-01T14:52:21.000Z"
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, [response]} = Humaans.PerformanceTemplates.list(client)
+      assert response.name == "Engineering Review"
+    end
+
+    test "returns error when not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ ->
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.PerformanceTemplates.list(client)
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ -> {:error, "boom"} end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.PerformanceTemplates.list(client)
+    end
+  end
+
+  describe "retrieve/2" do
+    test "retrieves a performance template", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/performance-templates/pt_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "pt_abc",
+             "name" => "Engineering Review",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-01T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.PerformanceTemplates.retrieve(client, "pt_abc")
+      assert response.name == "Engineering Review"
+    end
+  end
+
+  test "write actions are not exported" do
+    refute function_exported?(Humaans.PerformanceTemplates, :create, 2)
+    refute function_exported?(Humaans.PerformanceTemplates, :update, 3)
+    refute function_exported?(Humaans.PerformanceTemplates, :delete, 2)
+  end
+end

--- a/test/humaans/performance_templates_test.exs
+++ b/test/humaans/performance_templates_test.exs
@@ -14,7 +14,10 @@ defmodule Humaans.PerformanceTemplatesTest do
 
   describe "list/1" do
     test "returns a list of performance templates", %{client: client} do
-      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
+        assert Keyword.fetch!(opts, :method) == :get
         assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/performance-templates"
 
         {:ok,
@@ -38,11 +41,16 @@ defmodule Humaans.PerformanceTemplatesTest do
       end)
 
       assert {:ok, [response]} = Humaans.PerformanceTemplates.list(client)
+      assert response.id == "pt_abc"
+      assert response.company_id == "company_abc"
       assert response.name == "Engineering Review"
+      assert response.created_at == ~U[2025-01-01 08:44:42.000Z]
+      assert response.updated_at == ~U[2025-01-01 14:52:21.000Z]
     end
 
     test "returns error when not found", %{client: client} do
-      expect(Humaans.MockHTTPClient, :request, fn _, _ ->
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
         {:ok, %{status: 404, body: %{"error" => "Not found"}}}
       end)
 
@@ -51,7 +59,10 @@ defmodule Humaans.PerformanceTemplatesTest do
     end
 
     test "returns error when request fails", %{client: client} do
-      expect(Humaans.MockHTTPClient, :request, fn _, _ -> {:error, "boom"} end)
+      expect(Humaans.MockHTTPClient, :request, fn client_param, _opts ->
+        assert client_param == client
+        {:error, "boom"}
+      end)
 
       assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
                Humaans.PerformanceTemplates.list(client)
@@ -60,7 +71,11 @@ defmodule Humaans.PerformanceTemplatesTest do
 
   describe "retrieve/2" do
     test "retrieves a performance template", %{client: client} do
-      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+      expect(Humaans.MockHTTPClient, :request, fn client_param, opts ->
+        assert client_param == client
+        assert Keyword.fetch!(opts, :headers) == [{"Accept", "application/json"}]
+        assert Keyword.fetch!(opts, :method) == :get
+
         assert Keyword.fetch!(opts, :url) ==
                  "https://app.humaans.io/api/performance-templates/pt_abc"
 
@@ -69,6 +84,7 @@ defmodule Humaans.PerformanceTemplatesTest do
            status: 200,
            body: %{
              "id" => "pt_abc",
+             "companyId" => "company_abc",
              "name" => "Engineering Review",
              "createdAt" => "2025-01-01T08:44:42.000Z",
              "updatedAt" => "2025-01-01T14:52:21.000Z"
@@ -77,7 +93,11 @@ defmodule Humaans.PerformanceTemplatesTest do
       end)
 
       assert {:ok, response} = Humaans.PerformanceTemplates.retrieve(client, "pt_abc")
+      assert response.id == "pt_abc"
+      assert response.company_id == "company_abc"
       assert response.name == "Engineering Review"
+      assert response.created_at == ~U[2025-01-01 08:44:42.000Z]
+      assert response.updated_at == ~U[2025-01-01 14:52:21.000Z]
     end
   end
 

--- a/test/humaans_test.exs
+++ b/test/humaans_test.exs
@@ -248,4 +248,33 @@ defmodule HumaansTest do
   test "webhook_events/0 returns the WebhookEvents module" do
     assert Humaans.webhook_events() == Humaans.WebhookEvents
   end
+
+  test "performance_cycles/0 returns the PerformanceCycles module" do
+    assert Humaans.performance_cycles() == Humaans.PerformanceCycles
+  end
+
+  test "performance_templates/0 returns the PerformanceTemplates module" do
+    assert Humaans.performance_templates() == Humaans.PerformanceTemplates
+  end
+
+  test "performance_reviews/0 returns the PerformanceReviews module" do
+    assert Humaans.performance_reviews() == Humaans.PerformanceReviews
+  end
+
+  test "performance_instances/0 returns the PerformanceInstances module" do
+    assert Humaans.performance_instances() == Humaans.PerformanceInstances
+  end
+
+  test "performance_ratings/0 returns the PerformanceRatings module" do
+    assert Humaans.performance_ratings() == Humaans.PerformanceRatings
+  end
+
+  test "performance_summaries/0 returns the PerformanceSummaries module" do
+    assert Humaans.performance_summaries() == Humaans.PerformanceSummaries
+  end
+
+  test "performance_cycle_peer_nominations/0 returns the PerformanceCyclePeerNominations module" do
+    assert Humaans.performance_cycle_peer_nominations() ==
+             Humaans.PerformanceCyclePeerNominations
+  end
 end


### PR DESCRIPTION
:tipping_hand_person: Adds 7 read-only Performance resources to the library, completing the Performance API surface.

## Summary

**List + retrieve:**
- `Humaans.PerformanceCycles`: `/api/performance-cycles`
- `Humaans.PerformanceTemplates`: `/api/performance-templates`
- `Humaans.PerformanceReviews`: `/api/performance-reviews`
- `Humaans.PerformanceInstances`: `/api/performance-instances`

**Retrieve only:**
- `Humaans.PerformanceRatings`: `/api/performance-ratings`
- `Humaans.PerformanceSummaries`: `/api/performance-summaries`
- `Humaans.PerformanceCyclePeerNominations`: `/api/performance-cycle-peer-nominations`

Each declares its supported `actions: [...]` explicitly with a guard test confirming non-exported functions stay unexported. Helpers and README updated.

The struct fields cover the documented top-level shape (`id`, `companyId`, links, status, timestamps); the deeper schema for some Performance objects (e.g. nested template content, summary body shape) is sparsely documented in the public API reference and can be added additively if required.

## Test plan

- [x] `mix test` passes (~28 new tests)
- [x] `mix credo` clean
- [x] `mix format --check-formatted` clean