### PR TITLE
feat(requests-workflow): add Requests and Workflow family read-only resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,11 @@ Supported operators: `eq`, `in_`, `nin`, `gt`, `gte`, `lt`, `lte`. Use `Humaans.
 - `Humaans.PublicHolidayCalendarDays` - Work with public holiday calendar day resources
 - `Humaans.PublicHolidayCalendars` - List public holiday calendars (read-only)
 - `Humaans.PublicHolidays` - List public holidays (read-only)
+- `Humaans.RequestActivityLogs` - List and retrieve request activity log resources (read-only)
+- `Humaans.RequestComments` - List and retrieve request comment resources (read-only)
+- `Humaans.RequestReviews` - List and retrieve request review resources (read-only)
+- `Humaans.RequestTypes` - List and retrieve request type resources (read-only)
+- `Humaans.Requests` - List and retrieve request resources (read-only)
 - `Humaans.RoleMembers` - List and retrieve role member resources (read-only)
 - `Humaans.RolePermissions` - List and retrieve role permission resources (read-only)
 - `Humaans.Roles` - List and retrieve role resources (read-only)
@@ -164,6 +169,11 @@ Supported operators: `eq`, `in_`, `nin`, `gt`, `gte`, `lt`, `lte`. Use `Humaans.
 - `Humaans.TokenInfo` - Retrieve metadata about the current access token (`GET /token-info`)
 - `Humaans.WebhookEvents` - List and retrieve webhook event resources (read-only)
 - `Humaans.Webhooks` - Work with webhook subscription resources
+- `Humaans.WorkflowDependencies` - Retrieve workflow dependency resources (read-only)
+- `Humaans.WorkflowFormResponses` - Retrieve workflow form response resources (read-only)
+- `Humaans.WorkflowPublications` - Retrieve workflow publication resources (read-only)
+- `Humaans.WorkflowSlackActions` - Retrieve workflow Slack action resources (read-only)
+- `Humaans.WorkflowStats` - Retrieve workflow stat resources (read-only)
 - `Humaans.WorkingPatternAllocations` - Work with working pattern allocation resources
 - `Humaans.WorkingPatterns` - Work with working pattern resources
 

--- a/lib/humaans.ex
+++ b/lib/humaans.ex
@@ -378,6 +378,41 @@ defmodule Humaans do
   def query, do: Humaans.Query
 
   @doc """
+  Access the Requests API.
+
+  Returns the module that contains functions for working with request resources.
+  """
+  def requests, do: Humaans.Requests
+
+  @doc """
+  Access the Request Types API.
+
+  Returns the module that contains functions for working with request type resources.
+  """
+  def request_types, do: Humaans.RequestTypes
+
+  @doc """
+  Access the Request Reviews API.
+
+  Returns the module that contains functions for working with request review resources.
+  """
+  def request_reviews, do: Humaans.RequestReviews
+
+  @doc """
+  Access the Request Comments API.
+
+  Returns the module that contains functions for working with request comment resources.
+  """
+  def request_comments, do: Humaans.RequestComments
+
+  @doc """
+  Access the Request Activity Logs API.
+
+  Returns the module that contains functions for working with request activity log resources.
+  """
+  def request_activity_logs, do: Humaans.RequestActivityLogs
+
+  @doc """
   Access the Roles API.
 
   Returns the module that contains functions for working with role resources.
@@ -482,6 +517,41 @@ defmodule Humaans do
   Returns the module that contains functions for working with webhook event resources.
   """
   def webhook_events, do: Humaans.WebhookEvents
+
+  @doc """
+  Access the Workflow Dependencies API.
+
+  Returns the module that contains functions for working with workflow dependency resources.
+  """
+  def workflow_dependencies, do: Humaans.WorkflowDependencies
+
+  @doc """
+  Access the Workflow Form Responses API.
+
+  Returns the module that contains functions for working with workflow form response resources.
+  """
+  def workflow_form_responses, do: Humaans.WorkflowFormResponses
+
+  @doc """
+  Access the Workflow Publications API.
+
+  Returns the module that contains functions for working with workflow publication resources.
+  """
+  def workflow_publications, do: Humaans.WorkflowPublications
+
+  @doc """
+  Access the Workflow Slack Actions API.
+
+  Returns the module that contains functions for working with workflow Slack action resources.
+  """
+  def workflow_slack_actions, do: Humaans.WorkflowSlackActions
+
+  @doc """
+  Access the Workflow Stats API.
+
+  Returns the module that contains functions for working with workflow stat resources.
+  """
+  def workflow_stats, do: Humaans.WorkflowStats
 
   @doc """
   Access the Working Patterns API.

--- a/lib/humaans/request_activity_logs.ex
+++ b/lib/humaans/request_activity_logs.ex
@@ -1,0 +1,16 @@
+defmodule Humaans.RequestActivityLogs do
+  @moduledoc """
+  This module provides functions for listing and retrieving request activity
+  log resources in the Humaans API.  Request activity logs are read-only
+  via the API.
+  """
+
+  use Humaans.Resource,
+    path: "/request-activity-logs",
+    struct: Humaans.Resources.RequestActivityLog,
+    actions: [:list, :retrieve]
+
+  @type list_response ::
+          {:ok, [%Humaans.Resources.RequestActivityLog{}]} | {:error, Humaans.Error.t()}
+  @type response :: {:ok, %Humaans.Resources.RequestActivityLog{}} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/request_comments.ex
+++ b/lib/humaans/request_comments.ex
@@ -1,0 +1,15 @@
+defmodule Humaans.RequestComments do
+  @moduledoc """
+  This module provides functions for listing and retrieving request comment
+  resources in the Humaans API.  Request comments are read-only via the API.
+  """
+
+  use Humaans.Resource,
+    path: "/request-comments",
+    struct: Humaans.Resources.RequestComment,
+    actions: [:list, :retrieve]
+
+  @type list_response ::
+          {:ok, [%Humaans.Resources.RequestComment{}]} | {:error, Humaans.Error.t()}
+  @type response :: {:ok, %Humaans.Resources.RequestComment{}} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/request_reviews.ex
+++ b/lib/humaans/request_reviews.ex
@@ -1,0 +1,14 @@
+defmodule Humaans.RequestReviews do
+  @moduledoc """
+  This module provides functions for listing and retrieving request review
+  resources in the Humaans API.  Request reviews are read-only via the API.
+  """
+
+  use Humaans.Resource,
+    path: "/request-reviews",
+    struct: Humaans.Resources.RequestReview,
+    actions: [:list, :retrieve]
+
+  @type list_response :: {:ok, [%Humaans.Resources.RequestReview{}]} | {:error, Humaans.Error.t()}
+  @type response :: {:ok, %Humaans.Resources.RequestReview{}} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/request_types.ex
+++ b/lib/humaans/request_types.ex
@@ -1,0 +1,14 @@
+defmodule Humaans.RequestTypes do
+  @moduledoc """
+  This module provides functions for listing and retrieving request type
+  resources in the Humaans API.  Request types are read-only via the API.
+  """
+
+  use Humaans.Resource,
+    path: "/request-types",
+    struct: Humaans.Resources.RequestType,
+    actions: [:list, :retrieve]
+
+  @type list_response :: {:ok, [%Humaans.Resources.RequestType{}]} | {:error, Humaans.Error.t()}
+  @type response :: {:ok, %Humaans.Resources.RequestType{}} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/requests.ex
+++ b/lib/humaans/requests.ex
@@ -1,0 +1,14 @@
+defmodule Humaans.Requests do
+  @moduledoc """
+  This module provides functions for listing and retrieving request
+  resources in the Humaans API.  Requests are read-only via the API.
+  """
+
+  use Humaans.Resource,
+    path: "/requests",
+    struct: Humaans.Resources.Request,
+    actions: [:list, :retrieve]
+
+  @type list_response :: {:ok, [%Humaans.Resources.Request{}]} | {:error, Humaans.Error.t()}
+  @type response :: {:ok, %Humaans.Resources.Request{}} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/resources/request.ex
+++ b/lib/humaans/resources/request.ex
@@ -1,0 +1,38 @@
+defmodule Humaans.Resources.Request do
+  @moduledoc """
+  Representation of a Request resource.
+  """
+
+  defstruct [
+    :id,
+    :company_id,
+    :person_id,
+    :request_type_id,
+    :status,
+    :data,
+    :created_at,
+    :updated_at
+  ]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          company_id: binary | nil,
+          person_id: binary | nil,
+          request_type_id: binary | nil,
+          status: binary | nil,
+          data: map | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/resources/request_activity_log.ex
+++ b/lib/humaans/resources/request_activity_log.ex
@@ -1,0 +1,26 @@
+defmodule Humaans.Resources.RequestActivityLog do
+  @moduledoc """
+  Representation of a Request Activity Log resource.
+  """
+
+  defstruct [:id, :request_id, :person_id, :action, :data, :created_at]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:created_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          request_id: binary | nil,
+          person_id: binary | nil,
+          action: binary | nil,
+          data: map | nil,
+          created_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/resources/request_comment.ex
+++ b/lib/humaans/resources/request_comment.ex
@@ -1,0 +1,27 @@
+defmodule Humaans.Resources.RequestComment do
+  @moduledoc """
+  Representation of a Request Comment resource.
+  """
+
+  defstruct [:id, :request_id, :person_id, :body, :created_at, :updated_at]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          request_id: binary | nil,
+          person_id: binary | nil,
+          body: binary | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/resources/request_review.ex
+++ b/lib/humaans/resources/request_review.ex
@@ -1,0 +1,36 @@
+defmodule Humaans.Resources.RequestReview do
+  @moduledoc """
+  Representation of a Request Review resource.
+  """
+
+  defstruct [
+    :id,
+    :request_id,
+    :reviewer_id,
+    :status,
+    :decision,
+    :created_at,
+    :updated_at
+  ]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          request_id: binary | nil,
+          reviewer_id: binary | nil,
+          status: binary | nil,
+          decision: binary | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/resources/request_type.ex
+++ b/lib/humaans/resources/request_type.ex
@@ -1,0 +1,26 @@
+defmodule Humaans.Resources.RequestType do
+  @moduledoc """
+  Representation of a Request Type resource.
+  """
+
+  defstruct [:id, :company_id, :name, :created_at, :updated_at]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          company_id: binary | nil,
+          name: binary | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/resources/workflow_dependency.ex
+++ b/lib/humaans/resources/workflow_dependency.ex
@@ -1,0 +1,26 @@
+defmodule Humaans.Resources.WorkflowDependency do
+  @moduledoc """
+  Representation of a Workflow Dependency resource.
+  """
+
+  defstruct [:id, :workflow_id, :depends_on_workflow_id, :created_at, :updated_at]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          workflow_id: binary | nil,
+          depends_on_workflow_id: binary | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/resources/workflow_form_response.ex
+++ b/lib/humaans/resources/workflow_form_response.ex
@@ -1,0 +1,27 @@
+defmodule Humaans.Resources.WorkflowFormResponse do
+  @moduledoc """
+  Representation of a Workflow Form Response resource.
+  """
+
+  defstruct [:id, :workflow_id, :person_id, :data, :created_at, :updated_at]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          workflow_id: binary | nil,
+          person_id: binary | nil,
+          data: map | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/resources/workflow_publication.ex
+++ b/lib/humaans/resources/workflow_publication.ex
@@ -1,0 +1,26 @@
+defmodule Humaans.Resources.WorkflowPublication do
+  @moduledoc """
+  Representation of a Workflow Publication resource.
+  """
+
+  defstruct [:id, :workflow_id, :status, :created_at, :updated_at]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          workflow_id: binary | nil,
+          status: binary | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/resources/workflow_slack_action.ex
+++ b/lib/humaans/resources/workflow_slack_action.ex
@@ -1,0 +1,27 @@
+defmodule Humaans.Resources.WorkflowSlackAction do
+  @moduledoc """
+  Representation of a Workflow Slack Action resource.
+  """
+
+  defstruct [:id, :workflow_id, :channel, :message, :created_at, :updated_at]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          workflow_id: binary | nil,
+          channel: binary | nil,
+          message: binary | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/resources/workflow_stat.ex
+++ b/lib/humaans/resources/workflow_stat.ex
@@ -1,0 +1,26 @@
+defmodule Humaans.Resources.WorkflowStat do
+  @moduledoc """
+  Representation of a Workflow Stat resource.
+  """
+
+  defstruct [:id, :workflow_id, :stats, :created_at, :updated_at]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          workflow_id: binary | nil,
+          stats: map | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/workflow_dependencies.ex
+++ b/lib/humaans/workflow_dependencies.ex
@@ -1,0 +1,14 @@
+defmodule Humaans.WorkflowDependencies do
+  @moduledoc """
+  This module provides functions for retrieving workflow dependency resources
+  in the Humaans API.  Workflow dependencies are retrieve-only via the API.
+  """
+
+  use Humaans.Resource,
+    path: "/workflow-dependencies",
+    struct: Humaans.Resources.WorkflowDependency,
+    actions: [:retrieve]
+
+  @type response ::
+          {:ok, %Humaans.Resources.WorkflowDependency{}} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/workflow_form_responses.ex
+++ b/lib/humaans/workflow_form_responses.ex
@@ -1,0 +1,15 @@
+defmodule Humaans.WorkflowFormResponses do
+  @moduledoc """
+  This module provides functions for retrieving workflow form response
+  resources in the Humaans API.  Workflow form responses are retrieve-only
+  via the API.
+  """
+
+  use Humaans.Resource,
+    path: "/workflow-form-responses",
+    struct: Humaans.Resources.WorkflowFormResponse,
+    actions: [:retrieve]
+
+  @type response ::
+          {:ok, %Humaans.Resources.WorkflowFormResponse{}} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/workflow_publications.ex
+++ b/lib/humaans/workflow_publications.ex
@@ -1,0 +1,15 @@
+defmodule Humaans.WorkflowPublications do
+  @moduledoc """
+  This module provides functions for retrieving workflow publication
+  resources in the Humaans API.  Workflow publications are retrieve-only
+  via the API.
+  """
+
+  use Humaans.Resource,
+    path: "/workflow-publications",
+    struct: Humaans.Resources.WorkflowPublication,
+    actions: [:retrieve]
+
+  @type response ::
+          {:ok, %Humaans.Resources.WorkflowPublication{}} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/workflow_slack_actions.ex
+++ b/lib/humaans/workflow_slack_actions.ex
@@ -1,0 +1,15 @@
+defmodule Humaans.WorkflowSlackActions do
+  @moduledoc """
+  This module provides functions for retrieving workflow Slack action
+  resources in the Humaans API.  Workflow Slack actions are retrieve-only
+  via the API.
+  """
+
+  use Humaans.Resource,
+    path: "/workflow-slack-actions",
+    struct: Humaans.Resources.WorkflowSlackAction,
+    actions: [:retrieve]
+
+  @type response ::
+          {:ok, %Humaans.Resources.WorkflowSlackAction{}} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/workflow_stats.ex
+++ b/lib/humaans/workflow_stats.ex
@@ -1,0 +1,13 @@
+defmodule Humaans.WorkflowStats do
+  @moduledoc """
+  This module provides functions for retrieving workflow stat resources in
+  the Humaans API.  Workflow stats are retrieve-only via the API.
+  """
+
+  use Humaans.Resource,
+    path: "/workflow-stats",
+    struct: Humaans.Resources.WorkflowStat,
+    actions: [:retrieve]
+
+  @type response :: {:ok, %Humaans.Resources.WorkflowStat{}} | {:error, Humaans.Error.t()}
+end

--- a/test/humaans/request_activity_logs_test.exs
+++ b/test/humaans/request_activity_logs_test.exs
@@ -1,0 +1,90 @@
+defmodule Humaans.RequestActivityLogsTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.RequestActivityLogs
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "list/1" do
+    test "returns a list of request activity logs", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/request-activity-logs"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "total" => 1,
+             "limit" => 100,
+             "skip" => 0,
+             "data" => [
+               %{
+                 "id" => "ral_abc",
+                 "requestId" => "req_abc",
+                 "personId" => "person_def",
+                 "action" => "submitted",
+                 "data" => %{},
+                 "createdAt" => "2025-01-01T08:44:42.000Z"
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, [response]} = Humaans.RequestActivityLogs.list(client)
+      assert response.request_id == "req_abc"
+      assert response.action == "submitted"
+    end
+
+    test "returns error when not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ ->
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.RequestActivityLogs.list(client)
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ -> {:error, "boom"} end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.RequestActivityLogs.list(client)
+    end
+  end
+
+  describe "retrieve/2" do
+    test "retrieves a request activity log", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/request-activity-logs/ral_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "ral_abc",
+             "action" => "submitted",
+             "createdAt" => "2025-01-01T08:44:42.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.RequestActivityLogs.retrieve(client, "ral_abc")
+      assert response.action == "submitted"
+    end
+  end
+
+  test "write actions are not exported" do
+    refute function_exported?(Humaans.RequestActivityLogs, :create, 2)
+    refute function_exported?(Humaans.RequestActivityLogs, :update, 3)
+    refute function_exported?(Humaans.RequestActivityLogs, :delete, 2)
+  end
+end

--- a/test/humaans/request_comments_test.exs
+++ b/test/humaans/request_comments_test.exs
@@ -1,0 +1,91 @@
+defmodule Humaans.RequestCommentsTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.RequestComments
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "list/1" do
+    test "returns a list of request comments", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/request-comments"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "total" => 1,
+             "limit" => 100,
+             "skip" => 0,
+             "data" => [
+               %{
+                 "id" => "rc_abc",
+                 "requestId" => "req_abc",
+                 "personId" => "person_def",
+                 "body" => "Approved.",
+                 "createdAt" => "2025-01-01T08:44:42.000Z",
+                 "updatedAt" => "2025-01-01T14:52:21.000Z"
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, [response]} = Humaans.RequestComments.list(client)
+      assert response.request_id == "req_abc"
+      assert response.body == "Approved."
+    end
+
+    test "returns error when not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ ->
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.RequestComments.list(client)
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ -> {:error, "boom"} end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.RequestComments.list(client)
+    end
+  end
+
+  describe "retrieve/2" do
+    test "retrieves a request comment", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/request-comments/rc_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "rc_abc",
+             "body" => "Approved.",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-01T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.RequestComments.retrieve(client, "rc_abc")
+      assert response.body == "Approved."
+    end
+  end
+
+  test "write actions are not exported" do
+    refute function_exported?(Humaans.RequestComments, :create, 2)
+    refute function_exported?(Humaans.RequestComments, :update, 3)
+    refute function_exported?(Humaans.RequestComments, :delete, 2)
+  end
+end

--- a/test/humaans/request_reviews_test.exs
+++ b/test/humaans/request_reviews_test.exs
@@ -1,0 +1,92 @@
+defmodule Humaans.RequestReviewsTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.RequestReviews
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "list/1" do
+    test "returns a list of request reviews", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/request-reviews"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "total" => 1,
+             "limit" => 100,
+             "skip" => 0,
+             "data" => [
+               %{
+                 "id" => "rrev_abc",
+                 "requestId" => "req_abc",
+                 "reviewerId" => "person_def",
+                 "status" => "pending",
+                 "decision" => nil,
+                 "createdAt" => "2025-01-01T08:44:42.000Z",
+                 "updatedAt" => "2025-01-01T14:52:21.000Z"
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, [response]} = Humaans.RequestReviews.list(client)
+      assert response.request_id == "req_abc"
+      assert response.reviewer_id == "person_def"
+      assert response.status == "pending"
+    end
+
+    test "returns error when not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ ->
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.RequestReviews.list(client)
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ -> {:error, "boom"} end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.RequestReviews.list(client)
+    end
+  end
+
+  describe "retrieve/2" do
+    test "retrieves a request review", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/request-reviews/rrev_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "rrev_abc",
+             "requestId" => "req_abc",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-01T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.RequestReviews.retrieve(client, "rrev_abc")
+      assert response.request_id == "req_abc"
+    end
+  end
+
+  test "write actions are not exported" do
+    refute function_exported?(Humaans.RequestReviews, :create, 2)
+    refute function_exported?(Humaans.RequestReviews, :update, 3)
+    refute function_exported?(Humaans.RequestReviews, :delete, 2)
+  end
+end

--- a/test/humaans/request_types_test.exs
+++ b/test/humaans/request_types_test.exs
@@ -1,0 +1,88 @@
+defmodule Humaans.RequestTypesTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.RequestTypes
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "list/1" do
+    test "returns a list of request types", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/request-types"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "total" => 1,
+             "limit" => 100,
+             "skip" => 0,
+             "data" => [
+               %{
+                 "id" => "rt_abc",
+                 "companyId" => "company_abc",
+                 "name" => "Time off",
+                 "createdAt" => "2025-01-01T08:44:42.000Z",
+                 "updatedAt" => "2025-01-01T14:52:21.000Z"
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, [response]} = Humaans.RequestTypes.list(client)
+      assert response.name == "Time off"
+    end
+
+    test "returns error when not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ ->
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.RequestTypes.list(client)
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ -> {:error, "boom"} end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.RequestTypes.list(client)
+    end
+  end
+
+  describe "retrieve/2" do
+    test "retrieves a request type", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/request-types/rt_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "rt_abc",
+             "name" => "Time off",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-01T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.RequestTypes.retrieve(client, "rt_abc")
+      assert response.name == "Time off"
+    end
+  end
+
+  test "write actions are not exported" do
+    refute function_exported?(Humaans.RequestTypes, :create, 2)
+    refute function_exported?(Humaans.RequestTypes, :update, 3)
+    refute function_exported?(Humaans.RequestTypes, :delete, 2)
+  end
+end

--- a/test/humaans/requests_test.exs
+++ b/test/humaans/requests_test.exs
@@ -1,0 +1,94 @@
+defmodule Humaans.RequestsTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.Requests
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "list/1" do
+    test "returns a list of requests", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/requests"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "total" => 1,
+             "limit" => 100,
+             "skip" => 0,
+             "data" => [
+               %{
+                 "id" => "req_abc",
+                 "companyId" => "company_abc",
+                 "personId" => "person_abc",
+                 "requestTypeId" => "rt_abc",
+                 "status" => "pending",
+                 "data" => %{"foo" => "bar"},
+                 "createdAt" => "2025-01-01T08:44:42.000Z",
+                 "updatedAt" => "2025-01-01T14:52:21.000Z"
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, [response]} = Humaans.Requests.list(client)
+      assert response.id == "req_abc"
+      assert response.request_type_id == "rt_abc"
+      assert response.status == "pending"
+      assert response.data == %{"foo" => "bar"}
+    end
+
+    test "returns error when not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ ->
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.Requests.list(client)
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ -> {:error, "boom"} end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.Requests.list(client)
+    end
+  end
+
+  describe "retrieve/2" do
+    test "retrieves a request", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/requests/req_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "req_abc",
+             "status" => "pending",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-01T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.Requests.retrieve(client, "req_abc")
+      assert response.status == "pending"
+    end
+  end
+
+  test "write actions are not exported" do
+    refute function_exported?(Humaans.Requests, :create, 2)
+    refute function_exported?(Humaans.Requests, :update, 3)
+    refute function_exported?(Humaans.Requests, :delete, 2)
+  end
+end

--- a/test/humaans/workflow_dependencies_test.exs
+++ b/test/humaans/workflow_dependencies_test.exs
@@ -1,0 +1,62 @@
+defmodule Humaans.WorkflowDependenciesTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.WorkflowDependencies
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "retrieve/2" do
+    test "retrieves a workflow dependency", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/workflow-dependencies/wd_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "wd_abc",
+             "workflowId" => "wf_abc",
+             "dependsOnWorkflowId" => "wf_def",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-01T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.WorkflowDependencies.retrieve(client, "wd_abc")
+      assert response.workflow_id == "wf_abc"
+      assert response.depends_on_workflow_id == "wf_def"
+    end
+
+    test "returns error when not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ ->
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.WorkflowDependencies.retrieve(client, "missing")
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ -> {:error, "boom"} end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.WorkflowDependencies.retrieve(client, "wd_abc")
+    end
+  end
+
+  test "non-retrieve actions are not exported" do
+    refute function_exported?(Humaans.WorkflowDependencies, :list, 2)
+    refute function_exported?(Humaans.WorkflowDependencies, :create, 2)
+    refute function_exported?(Humaans.WorkflowDependencies, :update, 3)
+    refute function_exported?(Humaans.WorkflowDependencies, :delete, 2)
+  end
+end

--- a/test/humaans/workflow_form_responses_test.exs
+++ b/test/humaans/workflow_form_responses_test.exs
@@ -1,0 +1,61 @@
+defmodule Humaans.WorkflowFormResponsesTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.WorkflowFormResponses
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "retrieve/2" do
+    test "retrieves a workflow form response", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/workflow-form-responses/wfr_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "wfr_abc",
+             "workflowId" => "wf_abc",
+             "personId" => "person_abc",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-01T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.WorkflowFormResponses.retrieve(client, "wfr_abc")
+      assert response.workflow_id == "wf_abc"
+    end
+
+    test "returns error when not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ ->
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.WorkflowFormResponses.retrieve(client, "missing")
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ -> {:error, "boom"} end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.WorkflowFormResponses.retrieve(client, "wfr_abc")
+    end
+  end
+
+  test "non-retrieve actions are not exported" do
+    refute function_exported?(Humaans.WorkflowFormResponses, :list, 2)
+    refute function_exported?(Humaans.WorkflowFormResponses, :create, 2)
+    refute function_exported?(Humaans.WorkflowFormResponses, :update, 3)
+    refute function_exported?(Humaans.WorkflowFormResponses, :delete, 2)
+  end
+end

--- a/test/humaans/workflow_publications_test.exs
+++ b/test/humaans/workflow_publications_test.exs
@@ -1,0 +1,61 @@
+defmodule Humaans.WorkflowPublicationsTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.WorkflowPublications
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "retrieve/2" do
+    test "retrieves a workflow publication", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/workflow-publications/wp_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "wp_abc",
+             "workflowId" => "wf_abc",
+             "status" => "published",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-01T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.WorkflowPublications.retrieve(client, "wp_abc")
+      assert response.status == "published"
+    end
+
+    test "returns error when not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ ->
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.WorkflowPublications.retrieve(client, "missing")
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ -> {:error, "boom"} end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.WorkflowPublications.retrieve(client, "wp_abc")
+    end
+  end
+
+  test "non-retrieve actions are not exported" do
+    refute function_exported?(Humaans.WorkflowPublications, :list, 2)
+    refute function_exported?(Humaans.WorkflowPublications, :create, 2)
+    refute function_exported?(Humaans.WorkflowPublications, :update, 3)
+    refute function_exported?(Humaans.WorkflowPublications, :delete, 2)
+  end
+end

--- a/test/humaans/workflow_slack_actions_test.exs
+++ b/test/humaans/workflow_slack_actions_test.exs
@@ -1,0 +1,63 @@
+defmodule Humaans.WorkflowSlackActionsTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.WorkflowSlackActions
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "retrieve/2" do
+    test "retrieves a workflow Slack action", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/workflow-slack-actions/wsa_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "wsa_abc",
+             "workflowId" => "wf_abc",
+             "channel" => "#engineering",
+             "message" => "Welcome!",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-01T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.WorkflowSlackActions.retrieve(client, "wsa_abc")
+      assert response.channel == "#engineering"
+      assert response.message == "Welcome!"
+    end
+
+    test "returns error when not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ ->
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.WorkflowSlackActions.retrieve(client, "missing")
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ -> {:error, "boom"} end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.WorkflowSlackActions.retrieve(client, "wsa_abc")
+    end
+  end
+
+  test "non-retrieve actions are not exported" do
+    refute function_exported?(Humaans.WorkflowSlackActions, :list, 2)
+    refute function_exported?(Humaans.WorkflowSlackActions, :create, 2)
+    refute function_exported?(Humaans.WorkflowSlackActions, :update, 3)
+    refute function_exported?(Humaans.WorkflowSlackActions, :delete, 2)
+  end
+end

--- a/test/humaans/workflow_stats_test.exs
+++ b/test/humaans/workflow_stats_test.exs
@@ -1,0 +1,60 @@
+defmodule Humaans.WorkflowStatsTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.WorkflowStats
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "retrieve/2" do
+    test "retrieves a workflow stat", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/workflow-stats/ws_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "ws_abc",
+             "workflowId" => "wf_abc",
+             "stats" => %{"completed" => 12, "pending" => 3},
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-01T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.WorkflowStats.retrieve(client, "ws_abc")
+      assert response.stats == %{"completed" => 12, "pending" => 3}
+    end
+
+    test "returns error when not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ ->
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.WorkflowStats.retrieve(client, "missing")
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ -> {:error, "boom"} end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.WorkflowStats.retrieve(client, "ws_abc")
+    end
+  end
+
+  test "non-retrieve actions are not exported" do
+    refute function_exported?(Humaans.WorkflowStats, :list, 2)
+    refute function_exported?(Humaans.WorkflowStats, :create, 2)
+    refute function_exported?(Humaans.WorkflowStats, :update, 3)
+    refute function_exported?(Humaans.WorkflowStats, :delete, 2)
+  end
+end

--- a/test/humaans_test.exs
+++ b/test/humaans_test.exs
@@ -277,4 +277,44 @@ defmodule HumaansTest do
     assert Humaans.performance_cycle_peer_nominations() ==
              Humaans.PerformanceCyclePeerNominations
   end
+
+  test "requests/0 returns the Requests module" do
+    assert Humaans.requests() == Humaans.Requests
+  end
+
+  test "request_types/0 returns the RequestTypes module" do
+    assert Humaans.request_types() == Humaans.RequestTypes
+  end
+
+  test "request_reviews/0 returns the RequestReviews module" do
+    assert Humaans.request_reviews() == Humaans.RequestReviews
+  end
+
+  test "request_comments/0 returns the RequestComments module" do
+    assert Humaans.request_comments() == Humaans.RequestComments
+  end
+
+  test "request_activity_logs/0 returns the RequestActivityLogs module" do
+    assert Humaans.request_activity_logs() == Humaans.RequestActivityLogs
+  end
+
+  test "workflow_dependencies/0 returns the WorkflowDependencies module" do
+    assert Humaans.workflow_dependencies() == Humaans.WorkflowDependencies
+  end
+
+  test "workflow_form_responses/0 returns the WorkflowFormResponses module" do
+    assert Humaans.workflow_form_responses() == Humaans.WorkflowFormResponses
+  end
+
+  test "workflow_publications/0 returns the WorkflowPublications module" do
+    assert Humaans.workflow_publications() == Humaans.WorkflowPublications
+  end
+
+  test "workflow_slack_actions/0 returns the WorkflowSlackActions module" do
+    assert Humaans.workflow_slack_actions() == Humaans.WorkflowSlackActions
+  end
+
+  test "workflow_stats/0 returns the WorkflowStats module" do
+    assert Humaans.workflow_stats() == Humaans.WorkflowStats
+  end
 end


### PR DESCRIPTION
:tipping_hand_person: Adds 10 read-only resources from the Requests and Workflow families.

## Summary

**Requests family (list + retrieve):**
- `Humaans.Requests`: `/api/requests`
- `Humaans.RequestTypes`: `/api/request-types`
- `Humaans.RequestReviews`: `/api/request-reviews`
- `Humaans.RequestComments`: `/api/request-comments`
- `Humaans.RequestActivityLogs`: `/api/request-activity-logs`

**Workflow family (retrieve only):**
- `Humaans.WorkflowDependencies`: `/api/workflow-dependencies`
- `Humaans.WorkflowFormResponses`: \`/api/workflow-form-responses`
- `Humaans.WorkflowPublications`: `/api/workflow-publications`
- `Humaans.WorkflowSlackActions`: `/api/workflow-slack-actions`
- `Humaans.WorkflowStats`: `/api/workflow-stats`

Each declares its supported `actions: [...]` explicitly with a guard test confirming non-exported functions stay unexported. Helpers and README updated.

The struct fields cover the documented top-level shape; deeper schemas for Workflow objects are sparsely documented in the public API reference and can be added additively if required.

## Test plan

- [ ] `mix test` passes (~40 new tests)
- [ ] `mix credo` clean
- [ ] `mix format --check-formatted` clean