### PR TITLE
feat(esign): add Esign family read-only resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,11 +133,15 @@ Supported operators: `eq`, `in_`, `nin`, `gt`, `gte`, `lt`, `lte`. Use `Humaans.
 - `Humaans.EquipmentNames` - List equipment names (read-only)
 - `Humaans.EquipmentTypes` - List equipment types (read-only)
 - `Humaans.Equipment` - Work with equipment resources
+- `Humaans.EsignBulkRecipients` - List and retrieve e-signature bulk recipient resources (read-only)
+- `Humaans.EsignBulkTokens` - List and retrieve e-signature bulk token resources (read-only)
+- `Humaans.EsignBulks` - List and retrieve e-signature bulk resources (read-only)
+- `Humaans.EsignInstances` - List and retrieve e-signature instance resources (read-only)
+- `Humaans.EsignTemplates` - List and retrieve e-signature template resources (read-only)
 - `Humaans.IdentityDocumentTypes` - List identity document types (read-only)
 - `Humaans.IdentityDocuments` - Work with identity document resources
 - `Humaans.JobRoles` - Work with job role resources
 - `Humaans.Locations` - Work with location resources
-- `Humaans.Me` - Retrieve the authenticated user's profile (`GET /me`)
 - `Humaans.OKRs` - List and retrieve OKR resources (read-only)
 - `Humaans.PerformanceCyclePeerNominations` - Retrieve peer nomination resources (read-only)
 - `Humaans.PerformanceCycles` - List and retrieve performance cycle resources (read-only)
@@ -166,7 +170,6 @@ Supported operators: `eq`, `in_`, `nin`, `gt`, `gte`, `lt`, `lte`. Use `Humaans.
 - `Humaans.TimeAway` - Work with time away resources
 - `Humaans.TimesheetEntries` - Work with timesheet entry resources
 - `Humaans.TimesheetSubmissions` - Work with timesheet submission resources
-- `Humaans.TokenInfo` - Retrieve metadata about the current access token (`GET /token-info`)
 - `Humaans.WebhookEvents` - List and retrieve webhook event resources (read-only)
 - `Humaans.Webhooks` - Work with webhook subscription resources
 - `Humaans.WorkflowDependencies` - Retrieve workflow dependency resources (read-only)
@@ -176,11 +179,8 @@ Supported operators: `eq`, `in_`, `nin`, `gt`, `gte`, `lt`, `lte`. Use `Humaans.
 - `Humaans.WorkflowStats` - Retrieve workflow stat resources (read-only)
 - `Humaans.WorkingPatternAllocations` - Work with working pattern allocation resources
 - `Humaans.WorkingPatterns` - Work with working pattern resources
-- `Humaans.EsignTemplates` - List and retrieve e-signature template resources (read-only)
-- `Humaans.EsignInstances` - List and retrieve e-signature instance resources (read-only)
-- `Humaans.EsignBulks` - List and retrieve e-signature bulk resources (read-only)
-- `Humaans.EsignBulkRecipients` - List and retrieve e-signature bulk recipient resources (read-only)
-- `Humaans.EsignBulkTokens` - List and retrieve e-signature bulk token resources (read-only)
+- `Humaans.Me` - Retrieve the authenticated user's profile (`GET /me`)
+- `Humaans.TokenInfo` - Retrieve metadata about the current access token (`GET /token-info`)
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,11 @@ Supported operators: `eq`, `in_`, `nin`, `gt`, `gte`, `lt`, `lte`. Use `Humaans.
 - `Humaans.WorkflowStats` - Retrieve workflow stat resources (read-only)
 - `Humaans.WorkingPatternAllocations` - Work with working pattern allocation resources
 - `Humaans.WorkingPatterns` - Work with working pattern resources
+- `Humaans.EsignTemplates` - List and retrieve e-signature template resources (read-only)
+- `Humaans.EsignInstances` - List and retrieve e-signature instance resources (read-only)
+- `Humaans.EsignBulks` - List and retrieve e-signature bulk resources (read-only)
+- `Humaans.EsignBulkRecipients` - List and retrieve e-signature bulk recipient resources (read-only)
+- `Humaans.EsignBulkTokens` - List and retrieve e-signature bulk token resources (read-only)
 
 ## Development
 

--- a/lib/humaans.ex
+++ b/lib/humaans.ex
@@ -241,6 +241,41 @@ defmodule Humaans do
   def equipment_names, do: Humaans.EquipmentNames
 
   @doc """
+  Access the Esign Templates API.
+
+  Returns the module that contains functions for working with esign template resources.
+  """
+  def esign_templates, do: Humaans.EsignTemplates
+
+  @doc """
+  Access the Esign Instances API.
+
+  Returns the module that contains functions for working with esign instance resources.
+  """
+  def esign_instances, do: Humaans.EsignInstances
+
+  @doc """
+  Access the Esign Bulks API.
+
+  Returns the module that contains functions for working with esign bulk resources.
+  """
+  def esign_bulks, do: Humaans.EsignBulks
+
+  @doc """
+  Access the Esign Bulk Recipients API.
+
+  Returns the module that contains functions for working with esign bulk recipient resources.
+  """
+  def esign_bulk_recipients, do: Humaans.EsignBulkRecipients
+
+  @doc """
+  Access the Esign Bulk Tokens API.
+
+  Returns the module that contains functions for working with esign bulk token resources.
+  """
+  def esign_bulk_tokens, do: Humaans.EsignBulkTokens
+
+  @doc """
   Access the Identity Documents API.
 
   Returns the module that contains functions for working with identity document resources.

--- a/lib/humaans/esign_bulk_recipients.ex
+++ b/lib/humaans/esign_bulk_recipients.ex
@@ -1,0 +1,17 @@
+defmodule Humaans.EsignBulkRecipients do
+  @moduledoc """
+  This module provides functions for listing and retrieving e-signature
+  bulk recipient resources in the Humaans API.  Esign bulk recipients are
+  read-only via the API.
+  """
+
+  use Humaans.Resource,
+    path: "/esign-bulk-recipients",
+    struct: Humaans.Resources.EsignBulkRecipient,
+    actions: [:list, :retrieve]
+
+  @type list_response ::
+          {:ok, [%Humaans.Resources.EsignBulkRecipient{}]} | {:error, Humaans.Error.t()}
+  @type response ::
+          {:ok, %Humaans.Resources.EsignBulkRecipient{}} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/esign_bulk_tokens.ex
+++ b/lib/humaans/esign_bulk_tokens.ex
@@ -1,0 +1,16 @@
+defmodule Humaans.EsignBulkTokens do
+  @moduledoc """
+  This module provides functions for listing and retrieving e-signature
+  bulk token resources in the Humaans API.  Esign bulk tokens are
+  read-only via the API.
+  """
+
+  use Humaans.Resource,
+    path: "/esign-bulk-tokens",
+    struct: Humaans.Resources.EsignBulkToken,
+    actions: [:list, :retrieve]
+
+  @type list_response ::
+          {:ok, [%Humaans.Resources.EsignBulkToken{}]} | {:error, Humaans.Error.t()}
+  @type response :: {:ok, %Humaans.Resources.EsignBulkToken{}} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/esign_bulks.ex
+++ b/lib/humaans/esign_bulks.ex
@@ -1,0 +1,15 @@
+defmodule Humaans.EsignBulks do
+  @moduledoc """
+  This module provides functions for listing and retrieving e-signature
+  bulk resources in the Humaans API.  Esign bulks are read-only via the
+  API.
+  """
+
+  use Humaans.Resource,
+    path: "/esign-bulks",
+    struct: Humaans.Resources.EsignBulk,
+    actions: [:list, :retrieve]
+
+  @type list_response :: {:ok, [%Humaans.Resources.EsignBulk{}]} | {:error, Humaans.Error.t()}
+  @type response :: {:ok, %Humaans.Resources.EsignBulk{}} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/esign_instances.ex
+++ b/lib/humaans/esign_instances.ex
@@ -1,0 +1,15 @@
+defmodule Humaans.EsignInstances do
+  @moduledoc """
+  This module provides functions for listing and retrieving e-signature
+  instance resources in the Humaans API.  Esign instances are read-only
+  via the API.
+  """
+
+  use Humaans.Resource,
+    path: "/esign-instances",
+    struct: Humaans.Resources.EsignInstance,
+    actions: [:list, :retrieve]
+
+  @type list_response :: {:ok, [%Humaans.Resources.EsignInstance{}]} | {:error, Humaans.Error.t()}
+  @type response :: {:ok, %Humaans.Resources.EsignInstance{}} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/esign_templates.ex
+++ b/lib/humaans/esign_templates.ex
@@ -1,0 +1,15 @@
+defmodule Humaans.EsignTemplates do
+  @moduledoc """
+  This module provides functions for listing and retrieving e-signature
+  template resources in the Humaans API.  Esign templates are read-only
+  via the API.
+  """
+
+  use Humaans.Resource,
+    path: "/esign-templates",
+    struct: Humaans.Resources.EsignTemplate,
+    actions: [:list, :retrieve]
+
+  @type list_response :: {:ok, [%Humaans.Resources.EsignTemplate{}]} | {:error, Humaans.Error.t()}
+  @type response :: {:ok, %Humaans.Resources.EsignTemplate{}} | {:error, Humaans.Error.t()}
+end

--- a/lib/humaans/resources/esign_bulk.ex
+++ b/lib/humaans/resources/esign_bulk.ex
@@ -1,0 +1,36 @@
+defmodule Humaans.Resources.EsignBulk do
+  @moduledoc """
+  Representation of an Esign Bulk resource.
+  """
+
+  defstruct [
+    :id,
+    :company_id,
+    :esign_template_id,
+    :name,
+    :status,
+    :created_at,
+    :updated_at
+  ]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          company_id: binary | nil,
+          esign_template_id: binary | nil,
+          name: binary | nil,
+          status: binary | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/resources/esign_bulk_recipient.ex
+++ b/lib/humaans/resources/esign_bulk_recipient.ex
@@ -1,0 +1,37 @@
+defmodule Humaans.Resources.EsignBulkRecipient do
+  @moduledoc """
+  Representation of an Esign Bulk Recipient resource.
+  """
+
+  defstruct [
+    :id,
+    :esign_bulk_id,
+    :person_id,
+    :status,
+    :signed_at,
+    :created_at,
+    :updated_at
+  ]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:signed_at)
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          esign_bulk_id: binary | nil,
+          person_id: binary | nil,
+          status: binary | nil,
+          signed_at: DateTime.t() | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/resources/esign_bulk_token.ex
+++ b/lib/humaans/resources/esign_bulk_token.ex
@@ -1,0 +1,35 @@
+defmodule Humaans.Resources.EsignBulkToken do
+  @moduledoc """
+  Representation of an Esign Bulk Token resource.
+  """
+
+  defstruct [
+    :id,
+    :esign_bulk_recipient_id,
+    :token,
+    :expires_at,
+    :created_at,
+    :updated_at
+  ]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:expires_at)
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          esign_bulk_recipient_id: binary | nil,
+          token: binary | nil,
+          expires_at: DateTime.t() | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/resources/esign_instance.ex
+++ b/lib/humaans/resources/esign_instance.ex
@@ -1,0 +1,39 @@
+defmodule Humaans.Resources.EsignInstance do
+  @moduledoc """
+  Representation of an Esign Instance resource.
+  """
+
+  defstruct [
+    :id,
+    :company_id,
+    :esign_template_id,
+    :person_id,
+    :status,
+    :signed_at,
+    :created_at,
+    :updated_at
+  ]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:signed_at)
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          company_id: binary | nil,
+          esign_template_id: binary | nil,
+          person_id: binary | nil,
+          status: binary | nil,
+          signed_at: DateTime.t() | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/lib/humaans/resources/esign_template.ex
+++ b/lib/humaans/resources/esign_template.ex
@@ -1,0 +1,36 @@
+defmodule Humaans.Resources.EsignTemplate do
+  @moduledoc """
+  Representation of an Esign Template resource.
+  """
+
+  defstruct [
+    :id,
+    :company_id,
+    :name,
+    :body,
+    :status,
+    :created_at,
+    :updated_at
+  ]
+
+  use ExConstructor, :build
+
+  import Humaans.Resources.Timestamps
+
+  def new(data) do
+    data
+    |> build()
+    |> parse_datetime(:created_at)
+    |> parse_datetime(:updated_at)
+  end
+
+  @type t :: %__MODULE__{
+          id: binary | nil,
+          company_id: binary | nil,
+          name: binary | nil,
+          body: binary | nil,
+          status: binary | nil,
+          created_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+end

--- a/test/humaans/esign_bulk_recipients_test.exs
+++ b/test/humaans/esign_bulk_recipients_test.exs
@@ -1,0 +1,93 @@
+defmodule Humaans.EsignBulkRecipientsTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.EsignBulkRecipients
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "list/1" do
+    test "returns a list of esign bulk recipients", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/esign-bulk-recipients"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "total" => 1,
+             "limit" => 100,
+             "skip" => 0,
+             "data" => [
+               %{
+                 "id" => "ebr_abc",
+                 "esignBulkId" => "eb_abc",
+                 "personId" => "person_abc",
+                 "status" => "pending",
+                 "signedAt" => nil,
+                 "createdAt" => "2025-01-01T08:44:42.000Z",
+                 "updatedAt" => "2025-01-01T14:52:21.000Z"
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, [response]} = Humaans.EsignBulkRecipients.list(client)
+      assert response.esign_bulk_id == "eb_abc"
+      assert response.status == "pending"
+      assert response.signed_at == nil
+    end
+
+    test "returns error when not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ ->
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.EsignBulkRecipients.list(client)
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ -> {:error, "boom"} end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.EsignBulkRecipients.list(client)
+    end
+  end
+
+  describe "retrieve/2" do
+    test "retrieves an esign bulk recipient", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/esign-bulk-recipients/ebr_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "ebr_abc",
+             "esignBulkId" => "eb_abc",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-01T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.EsignBulkRecipients.retrieve(client, "ebr_abc")
+      assert response.esign_bulk_id == "eb_abc"
+    end
+  end
+
+  test "write actions are not exported" do
+    refute function_exported?(Humaans.EsignBulkRecipients, :create, 2)
+    refute function_exported?(Humaans.EsignBulkRecipients, :update, 3)
+    refute function_exported?(Humaans.EsignBulkRecipients, :delete, 2)
+  end
+end

--- a/test/humaans/esign_bulk_tokens_test.exs
+++ b/test/humaans/esign_bulk_tokens_test.exs
@@ -1,0 +1,92 @@
+defmodule Humaans.EsignBulkTokensTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.EsignBulkTokens
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "list/1" do
+    test "returns a list of esign bulk tokens", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/esign-bulk-tokens"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "total" => 1,
+             "limit" => 100,
+             "skip" => 0,
+             "data" => [
+               %{
+                 "id" => "ebt_abc",
+                 "esignBulkRecipientId" => "ebr_abc",
+                 "token" => "tok_xyz",
+                 "expiresAt" => "2025-02-01T08:44:42.000Z",
+                 "createdAt" => "2025-01-01T08:44:42.000Z",
+                 "updatedAt" => "2025-01-01T14:52:21.000Z"
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, [response]} = Humaans.EsignBulkTokens.list(client)
+      assert response.esign_bulk_recipient_id == "ebr_abc"
+      assert response.token == "tok_xyz"
+      assert response.expires_at == ~U[2025-02-01 08:44:42.000Z]
+    end
+
+    test "returns error when not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ ->
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.EsignBulkTokens.list(client)
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ -> {:error, "boom"} end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.EsignBulkTokens.list(client)
+    end
+  end
+
+  describe "retrieve/2" do
+    test "retrieves an esign bulk token", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+        assert Keyword.fetch!(opts, :url) ==
+                 "https://app.humaans.io/api/esign-bulk-tokens/ebt_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "ebt_abc",
+             "token" => "tok_xyz",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-01T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.EsignBulkTokens.retrieve(client, "ebt_abc")
+      assert response.token == "tok_xyz"
+    end
+  end
+
+  test "write actions are not exported" do
+    refute function_exported?(Humaans.EsignBulkTokens, :create, 2)
+    refute function_exported?(Humaans.EsignBulkTokens, :update, 3)
+    refute function_exported?(Humaans.EsignBulkTokens, :delete, 2)
+  end
+end

--- a/test/humaans/esign_bulks_test.exs
+++ b/test/humaans/esign_bulks_test.exs
@@ -1,0 +1,91 @@
+defmodule Humaans.EsignBulksTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.EsignBulks
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "list/1" do
+    test "returns a list of esign bulks", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/esign-bulks"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "total" => 1,
+             "limit" => 100,
+             "skip" => 0,
+             "data" => [
+               %{
+                 "id" => "eb_abc",
+                 "companyId" => "company_abc",
+                 "esignTemplateId" => "et_abc",
+                 "name" => "Q1 Offer Letters",
+                 "status" => "sent",
+                 "createdAt" => "2025-01-01T08:44:42.000Z",
+                 "updatedAt" => "2025-01-01T14:52:21.000Z"
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, [response]} = Humaans.EsignBulks.list(client)
+      assert response.name == "Q1 Offer Letters"
+      assert response.esign_template_id == "et_abc"
+    end
+
+    test "returns error when not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ ->
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.EsignBulks.list(client)
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ -> {:error, "boom"} end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.EsignBulks.list(client)
+    end
+  end
+
+  describe "retrieve/2" do
+    test "retrieves an esign bulk", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/esign-bulks/eb_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "eb_abc",
+             "name" => "Q1 Offer Letters",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-01T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.EsignBulks.retrieve(client, "eb_abc")
+      assert response.name == "Q1 Offer Letters"
+    end
+  end
+
+  test "write actions are not exported" do
+    refute function_exported?(Humaans.EsignBulks, :create, 2)
+    refute function_exported?(Humaans.EsignBulks, :update, 3)
+    refute function_exported?(Humaans.EsignBulks, :delete, 2)
+  end
+end

--- a/test/humaans/esign_instances_test.exs
+++ b/test/humaans/esign_instances_test.exs
@@ -1,0 +1,94 @@
+defmodule Humaans.EsignInstancesTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.EsignInstances
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "list/1" do
+    test "returns a list of esign instances", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/esign-instances"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "total" => 1,
+             "limit" => 100,
+             "skip" => 0,
+             "data" => [
+               %{
+                 "id" => "ei_abc",
+                 "companyId" => "company_abc",
+                 "esignTemplateId" => "et_abc",
+                 "personId" => "person_abc",
+                 "status" => "signed",
+                 "signedAt" => "2025-01-15T08:44:42.000Z",
+                 "createdAt" => "2025-01-01T08:44:42.000Z",
+                 "updatedAt" => "2025-01-15T14:52:21.000Z"
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, [response]} = Humaans.EsignInstances.list(client)
+      assert response.esign_template_id == "et_abc"
+      assert response.status == "signed"
+      assert response.signed_at == ~U[2025-01-15 08:44:42.000Z]
+    end
+
+    test "returns error when not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ ->
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.EsignInstances.list(client)
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ -> {:error, "boom"} end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.EsignInstances.list(client)
+    end
+  end
+
+  describe "retrieve/2" do
+    test "retrieves an esign instance", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/esign-instances/ei_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "ei_abc",
+             "esignTemplateId" => "et_abc",
+             "status" => "signed",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-15T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.EsignInstances.retrieve(client, "ei_abc")
+      assert response.esign_template_id == "et_abc"
+    end
+  end
+
+  test "write actions are not exported" do
+    refute function_exported?(Humaans.EsignInstances, :create, 2)
+    refute function_exported?(Humaans.EsignInstances, :update, 3)
+    refute function_exported?(Humaans.EsignInstances, :delete, 2)
+  end
+end

--- a/test/humaans/esign_templates_test.exs
+++ b/test/humaans/esign_templates_test.exs
@@ -1,0 +1,91 @@
+defmodule Humaans.EsignTemplatesTest do
+  use ExUnit.Case, async: true
+
+  import Mox, only: [expect: 3, verify_on_exit!: 1]
+
+  doctest Humaans.EsignTemplates
+
+  setup :verify_on_exit!
+
+  setup_all do
+    client = Humaans.new(access_token: "some access token", http_client: Humaans.MockHTTPClient)
+    [client: client]
+  end
+
+  describe "list/1" do
+    test "returns a list of esign templates", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/esign-templates"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "total" => 1,
+             "limit" => 100,
+             "skip" => 0,
+             "data" => [
+               %{
+                 "id" => "et_abc",
+                 "companyId" => "company_abc",
+                 "name" => "Offer Letter",
+                 "body" => "Welcome to Acme...",
+                 "status" => "active",
+                 "createdAt" => "2025-01-01T08:44:42.000Z",
+                 "updatedAt" => "2025-01-01T14:52:21.000Z"
+               }
+             ]
+           }
+         }}
+      end)
+
+      assert {:ok, [response]} = Humaans.EsignTemplates.list(client)
+      assert response.name == "Offer Letter"
+      assert response.status == "active"
+    end
+
+    test "returns error when not found", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ ->
+        {:ok, %{status: 404, body: %{"error" => "Not found"}}}
+      end)
+
+      assert {:error, %Humaans.Error{type: :api_error, status: 404}} =
+               Humaans.EsignTemplates.list(client)
+    end
+
+    test "returns error when request fails", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, _ -> {:error, "boom"} end)
+
+      assert {:error, %Humaans.Error{type: :network_error, reason: "boom"}} =
+               Humaans.EsignTemplates.list(client)
+    end
+  end
+
+  describe "retrieve/2" do
+    test "retrieves an esign template", %{client: client} do
+      expect(Humaans.MockHTTPClient, :request, fn _, opts ->
+        assert Keyword.fetch!(opts, :url) == "https://app.humaans.io/api/esign-templates/et_abc"
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "id" => "et_abc",
+             "name" => "Offer Letter",
+             "createdAt" => "2025-01-01T08:44:42.000Z",
+             "updatedAt" => "2025-01-01T14:52:21.000Z"
+           }
+         }}
+      end)
+
+      assert {:ok, response} = Humaans.EsignTemplates.retrieve(client, "et_abc")
+      assert response.name == "Offer Letter"
+    end
+  end
+
+  test "write actions are not exported" do
+    refute function_exported?(Humaans.EsignTemplates, :create, 2)
+    refute function_exported?(Humaans.EsignTemplates, :update, 3)
+    refute function_exported?(Humaans.EsignTemplates, :delete, 2)
+  end
+end

--- a/test/humaans_test.exs
+++ b/test/humaans_test.exs
@@ -317,4 +317,24 @@ defmodule HumaansTest do
   test "workflow_stats/0 returns the WorkflowStats module" do
     assert Humaans.workflow_stats() == Humaans.WorkflowStats
   end
+
+  test "esign_templates/0 returns the EsignTemplates module" do
+    assert Humaans.esign_templates() == Humaans.EsignTemplates
+  end
+
+  test "esign_instances/0 returns the EsignInstances module" do
+    assert Humaans.esign_instances() == Humaans.EsignInstances
+  end
+
+  test "esign_bulks/0 returns the EsignBulks module" do
+    assert Humaans.esign_bulks() == Humaans.EsignBulks
+  end
+
+  test "esign_bulk_recipients/0 returns the EsignBulkRecipients module" do
+    assert Humaans.esign_bulk_recipients() == Humaans.EsignBulkRecipients
+  end
+
+  test "esign_bulk_tokens/0 returns the EsignBulkTokens module" do
+    assert Humaans.esign_bulk_tokens() == Humaans.EsignBulkTokens
+  end
 end


### PR DESCRIPTION
:tipping_hand_person: Adds 5 read-only resources for the e-signature workflow surface.

## Summary

**List + retrieve:**
- \`Humaans.EsignTemplates\` — \`/api/esign-templates\` (template definitions)
- \`Humaans.EsignInstances\` — \`/api/esign-instances\` (signing instances per person)
- \`Humaans.EsignBulks\` — \`/api/esign-bulks\` (bulk send batches)
- \`Humaans.EsignBulkRecipients\` — \`/api/esign-bulk-recipients\` (per-person recipient records)
- \`Humaans.EsignBulkTokens\` — \`/api/esign-bulk-tokens\` (per-recipient signing tokens)

Each declares \`actions: [:list, :retrieve]\` explicitly with a guard test confirming non-exported functions stay unexported. Helpers and README updated.

Struct fields cover the documented top-level shape (\`id\`, parent ids, status, timestamps). Field schemas for some Esign objects are sparsely documented in the public API reference and can be added additively if required.

## Test plan

- [ ] \`mix test\` passes (~22 new tests)
- [ ] \`mix credo\` clean
- [ ] \`mix format --check-formatted\` clean